### PR TITLE
Fix links to ghostscript windows downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Install Tesseract, Ghostscript, GhostPCL, ImageMagick binaries
  * `apt-get install libdmtx0b`
 * Windows
  * https://github.com/UB-Mannheim/tesseract/wiki
- * https://www.ghostscript.com/download/gsdnld.html
- * https://www.ghostscript.com/download/gpcldnld.html
+ * https://ghostscript.com/releases/gsdnld.html
+ * https://ghostscript.com/releases/gpcldnld.html
  * https://imagemagick.org/script/download.php
 
 


### PR DESCRIPTION
Hi @manykarim ,

while going through the installation process for Windows, I noticed that the links to the ghostscript binaries were broken. I replaced them by what I think now is the most fitting option.