### PR TITLE
Fixed threshold comparison for identical matches (min_val =0.0)

### DIFF
--- a/DocTest/VisualTest.py
+++ b/DocTest/VisualTest.py
@@ -932,7 +932,7 @@ class VisualTest(object):
             res = cv2.matchTemplate(
                 img_gray, template_gray, cv2.TM_SQDIFF_NORMED)
             min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)
-            if (min_val < threshold):
+            if (min_val <= threshold):
                 top_left = min_loc
                 bottom_right = (top_left[0] + w, top_left[1] + h)
                 if take_screenshots:


### PR DESCRIPTION
I tested the image comparison with a template image PDF which is a cropped version of the original PDF. 
In that case, I have a perfect match with `min_val` is at `0.0`. 
If I set a threshold of `0.0` (= PASS only if there _is_ an exact match) the test fails. 
The fix is to compare with "minor or equal" threshold.