### PR TITLE
Fixed exception raise

### DIFF
--- a/DocTest/VisualTest.py
+++ b/DocTest/VisualTest.py
@@ -940,7 +940,7 @@ class VisualTest(object):
                     self.add_screenshot_to_log(img, "image_with_template")
                 return {"pt1": top_left, "pt2": bottom_right}
             else:
-                AssertionError('The Template was not found in the Image.')
+                raise AssertionError('The Template was not found in the Image.')
 
 
 


### PR DESCRIPTION
This PR fixes the bug that no error is being thrown when the template does not match. 
(missing `raise` statement)