### PR TITLE
Added optional template image cropping, added template image to log

### DIFF
--- a/DocTest/VisualTest.py
+++ b/DocTest/VisualTest.py
@@ -967,7 +967,7 @@ class VisualTest(object):
             if match:
                 return {"pt1": top_left, "pt2": bottom_right}
             else:
-                AssertionError('The Template was not found in the Image.')
+                raise AssertionError('The Template was not found in the Image.')
 
 
 


### PR DESCRIPTION
This PR adds a new functionality to the keyword `Image Should Contain Template`:

Before, a haystack file had to be cropped to get the needle file (which is cumbersome with pdfs...).

`Image Should Contain Template` got 4 more optional parameters x1/y1/x2/y2 to define a rectangle which defines the are the template file should be cropped to.

It may be a matter of personal preference, but I think that both the haystack and the needle image should be shown in the log, both in the OK case and in the error case. 
After all, you want to know what the library has compared in fact. 
A manual review afterwards is far more time-consuming, so I think the few kb increase in the HTML log is justified. 


