### PR TITLE
Fix word-pattern mask sizing for newer PyMuPDF

### DIFF
--- a/DocTest/DocumentRepresentation.py
+++ b/DocTest/DocumentRepresentation.py
@@ -312,8 +312,23 @@ class Page:
             if self.pdf_text_words:
                 for word in self.pdf_text_words:
                     if search_pattern.match(word[4]):
-                        (x, y, w, h) = (word[0]*self.dpi/72, word[1]*self.dpi/72, word[2]*self.dpi/72, word[3]*self.dpi/72)
-                        text_mask = {"x": int(x) - xoffset, "y": int(y) - yoffset, "width": int(w) + 2 * xoffset, "height": int(h) + 2 * yoffset}
+                        x0, y0 = word[0], word[1]
+                        x = x0 * self.dpi / 72
+                        y = y0 * self.dpi / 72
+                        if word[2] > x0:
+                            # PyMuPDF >= 1.25 returns (x0, y0, x1, y1, text, ...)
+                            w = (word[2] - x0) * self.dpi / 72
+                            h = (word[3] - y0) * self.dpi / 72
+                        else:
+                            # Older versions return (x0, y0, width, height, text, ...)
+                            w = word[2] * self.dpi / 72
+                            h = word[3] * self.dpi / 72
+                        text_mask = {
+                            "x": int(x) - xoffset,
+                            "y": int(y) - yoffset,
+                            "width": int(w) + 2 * xoffset,
+                            "height": int(h) + 2 * yoffset,
+                        }
                         self.pixel_ignore_areas.append(text_mask)
         else:
             if self.pdf_text_dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/manykarim/robotframework-doctestlibrary"
 [tool.poetry.dependencies]
 python = "^3.8.1"
 PyMuPDF = [
-    { version = ">=1.23.1, <1.25.0", python = ">=3.8, <3.9" },
+    { version = ">=1.23.1, !=1.25.0, <1.26.0", python = ">=3.8, <3.9" },
     { version = ">=1.26.0", python = ">=3.9" },
 ]
 imutils = "*"

--- a/utest/test_masks.py
+++ b/utest/test_masks.py
@@ -28,3 +28,14 @@ def test_pdf_text_mask(testdata_dir):
     img = DocumentRepresentation(testdata_dir / 'sample_1_page.pdf', ignore_area_file=testdata_dir / 'pdf_pattern_mask.json')
     assert len(img.abstract_ignore_areas)==2
     assert np.not_equal(img.pages[0].get_image_with_ignore_areas(), img.pages[0].image).any()
+
+
+def test_pdf_word_pattern_mask_dimensions(testdata_dir):
+    img = DocumentRepresentation(
+        testdata_dir / 'sample_1_page.pdf',
+        dpi=300,
+        ignore_area_file=testdata_dir / 'pdf_pattern_mask.json',
+    )
+    word_mask = img.pages[0].pixel_ignore_areas[0]
+    assert word_mask['width'] == 350
+    assert word_mask['height'] == 47


### PR DESCRIPTION
## Summary
- handle PyMuPDF 1.25+ `(x0, y0, x1, y1)` tuples when building word-pattern masks
- allow PyMuPDF 1.25.x on Python 3.8
- test correct dimensions for PDF word-pattern masks

## Testing
- `poetry run invoke tests` *(fails: AssertionError in OCR-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a327c561008331b2ca4be2c4f005a6