### PR TITLE
fix: implement riskstorming v1 mitigations across 9 risk areas

### DIFF
--- a/DocTest/CapabilityCheck.py
+++ b/DocTest/CapabilityCheck.py
@@ -1,0 +1,271 @@
+"""Preflight capability checker for DocTest library.
+
+Detects whether optional external binaries (Tesseract, Ghostscript, GhostPCL,
+ImageMagick) and Python packages (PyMuPDF, pyzbar, openai) are available before
+tests run.  This avoids cryptic runtime errors when a dependency is missing.
+
+Usage from Robot Framework::
+
+    Library    DocTest.CapabilityCheck
+
+    *** Test Cases ***
+    Verify Environment
+        ${caps}=    Check DocTest Environment
+        Log    ${caps}
+
+Usage from Python::
+
+    from DocTest.CapabilityCheck import check_all_capabilities, format_capability_report
+    caps = check_all_capabilities()
+    print(format_capability_report(caps))
+"""
+
+import importlib
+import logging
+import shutil
+import subprocess
+from typing import Dict, List, Optional
+
+from robot.api.deco import keyword, library
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Capability registry
+# ---------------------------------------------------------------------------
+
+CAPABILITY_REGISTRY: Dict[str, Dict[str, str]] = {
+    "tesseract": {
+        "binary": "tesseract",
+        "feature": "OCR text extraction",
+        "install_hint": "apt install tesseract-ocr (Linux) / brew install tesseract (macOS)",
+    },
+    "ghostscript": {
+        "binary": "gs",
+        "fallback_binaries": "gswin64c,gswin32c,ghostscript",
+        "feature": "PDF/PostScript rendering",
+        "install_hint": "apt install ghostscript (Linux) / brew install ghostscript (macOS)",
+    },
+    "ghostpcl": {
+        "binary": "pcl6",
+        "fallback_binaries": "gpcl6win64,gpcl6win32,gpcl6",
+        "feature": "PCL document rendering",
+        "install_hint": (
+            "Install GhostPCL from https://ghostscript.com/releases/gpcldnld.html"
+        ),
+    },
+    "imagemagick": {
+        "binary": "magick",
+        "fallback_binaries": "convert",
+        "feature": "Image format conversion",
+        "install_hint": (
+            "apt install imagemagick (Linux) / brew install imagemagick (macOS)"
+        ),
+    },
+}
+
+PYTHON_PACKAGE_REGISTRY: Dict[str, Dict[str, str]] = {
+    "pymupdf": {
+        "import_name": "fitz",
+        "feature": "PDF rendering and text extraction",
+        "install_hint": "pip install PyMuPDF",
+    },
+    "pyzbar": {
+        "import_name": "pyzbar",
+        "feature": "Barcode detection and decoding",
+        "install_hint": "pip install pyzbar",
+    },
+    "openai": {
+        "import_name": "openai",
+        "feature": "LLM-assisted image comparison",
+        "install_hint": 'pip install "robotframework-doctestlibrary[ai]"',
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def check_binary(name: str) -> Optional[str]:
+    """Return the absolute path of *name* if it is on ``$PATH``, else ``None``.
+
+    Uses :func:`shutil.which` internally.
+    """
+    try:
+        return shutil.which(name)
+    except Exception:
+        return None
+
+
+def check_python_package(name: str) -> bool:
+    """Return ``True`` if the Python package *name* can be imported."""
+    try:
+        importlib.import_module(name)
+        return True
+    except Exception:
+        return False
+
+
+def _get_version(binary_path: str) -> Optional[str]:
+    """Try to obtain a version string from *binary_path*.
+
+    Attempts ``--version`` first, then ``-version``.  Returns ``None`` on
+    any failure so the caller can proceed without version info.
+    """
+    for flag in ("--version", "-version"):
+        try:
+            result = subprocess.run(
+                [binary_path, flag],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            output = (result.stdout or result.stderr or "").strip()
+            if output:
+                # Return the first non-empty line.
+                return output.splitlines()[0]
+        except Exception:
+            continue
+    return None
+
+
+def check_all_capabilities() -> Dict[str, Dict]:
+    """Check every registered capability and return a structured report.
+
+    Returns a ``dict`` keyed by capability name.  Each value is a ``dict``
+    containing at least ``"available"`` (bool) and ``"feature"`` (str).
+    """
+    results: Dict[str, Dict] = {}
+
+    # -- Binary capabilities --
+    for name, info in CAPABILITY_REGISTRY.items():
+        entry: Dict = {
+            "available": False,
+            "feature": info["feature"],
+            "path": None,
+        }
+
+        # Try the primary binary first, then any fallbacks.
+        binaries_to_try: List[str] = [info["binary"]]
+        fallback_str = info.get("fallback_binaries", "")
+        if fallback_str:
+            binaries_to_try.extend(
+                b.strip() for b in fallback_str.split(",") if b.strip()
+            )
+
+        used_fallback = False
+        for idx, binary_name in enumerate(binaries_to_try):
+            path = check_binary(binary_name)
+            if path is not None:
+                entry["available"] = True
+                entry["path"] = path
+                version = _get_version(path)
+                if version:
+                    entry["version"] = version
+                if idx > 0:
+                    used_fallback = True
+                    entry["note"] = f"Using fallback '{binary_name}' command"
+                break
+
+        if not entry["available"]:
+            entry["install_hint"] = info["install_hint"]
+
+        results[name] = entry
+
+    # -- Python package capabilities --
+    for name, info in PYTHON_PACKAGE_REGISTRY.items():
+        import_name = info["import_name"]
+        available = check_python_package(import_name)
+        entry = {
+            "available": available,
+            "feature": info["feature"],
+            "package": import_name,
+        }
+        if not available:
+            entry["install_hint"] = info["install_hint"]
+        results[name] = entry
+
+    return results
+
+
+def format_capability_report(capabilities: Dict[str, Dict]) -> str:
+    """Format *capabilities* into a human-readable report string."""
+    lines: List[str] = []
+    lines.append("DocTest Environment Capability Report")
+    lines.append("=" * 42)
+
+    available_items: List[str] = []
+    missing_items: List[str] = []
+
+    for name, info in capabilities.items():
+        status = "OK" if info["available"] else "MISSING"
+        feature = info.get("feature", "")
+        line = f"  [{status:>7}] {name:<15} - {feature}"
+        if info["available"]:
+            path = info.get("path")
+            version = info.get("version")
+            note = info.get("note")
+            details: List[str] = []
+            if path:
+                details.append(f"path: {path}")
+            if version:
+                details.append(f"version: {version}")
+            if note:
+                details.append(note)
+            if details:
+                line += f" ({', '.join(details)})"
+            available_items.append(line)
+        else:
+            hint = info.get("install_hint", "")
+            if hint:
+                line += f"\n{'':>28}Install: {hint}"
+            missing_items.append(line)
+
+    if available_items:
+        lines.append("")
+        lines.append("Available:")
+        lines.extend(available_items)
+
+    if missing_items:
+        lines.append("")
+        lines.append("Missing:")
+        lines.extend(missing_items)
+
+    lines.append("")
+    total = len(capabilities)
+    ok_count = sum(1 for v in capabilities.values() if v["available"])
+    lines.append(f"Summary: {ok_count}/{total} capabilities available")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Robot Framework library
+# ---------------------------------------------------------------------------
+
+
+@library(scope="GLOBAL")
+class CapabilityCheck:
+    """Preflight capability checker for the DocTest library.
+
+    Provides a keyword to detect whether optional external binaries and
+    Python packages required by various DocTest features are installed.
+    """
+
+    ROBOT_LIBRARY_VERSION = "1.0"
+
+    @keyword("Check DocTest Environment")
+    def check_doctest_environment(self) -> Dict[str, Dict]:
+        """Check and report available capabilities for DocTest library.
+
+        Returns a structured ``dict`` keyed by capability name and logs a
+        human-readable report.
+
+        Example:
+        | ${caps}= | Check DocTest Environment |
+        | Log       | ${caps}                   |
+        """
+        capabilities = check_all_capabilities()
+        report = format_capability_report(capabilities)
+        logger.info(report)
+        return capabilities

--- a/DocTest/DocumentRepresentation.py
+++ b/DocTest/DocumentRepresentation.py
@@ -21,6 +21,8 @@ from DocTest.PdfStructureModels import (
 from DocTest.config import DEFAULT_DPI, OCR_ENGINE_DEFAULT, DEFAULT_CONFIDENCE, MINIMUM_OCR_RESOLUTION, ADD_PIXELS_TO_IGNORE_AREA, TESSERACT_CONFIG
 import tempfile
 
+logger = logging.getLogger(__name__)
+
 # Constants
 
 
@@ -569,7 +571,7 @@ class Page:
     def identify_barcodes_with_zbar(self):
         try:
             from pyzbar import pyzbar
-        except:
+        except ImportError:
             logging.debug('Failed to import pyzbar', exc_info=True)
             return
         image_height = self.image.shape[0]
@@ -592,19 +594,19 @@ class Page:
     def identify_datamatrices(self):
         try:
             from pylibdmtx import pylibdmtx
-        except:
+        except ImportError:
             logging.debug('Failed to import pylibdmtx', exc_info=True)
             return
         logging.debug("Identify datamatrices")
         image_height = self.image.shape[0]
         try:
             barcodes = pylibdmtx.decode(self.image, timeout=5000)
-        except:
+        except Exception:
             logging.debug("pylibdmtx could not be loaded",exc_info=True)
             return
         #Add barcode as placehoder
         for barcode in barcodes:
-            print(barcode)
+            logger.debug("Detected barcode: %s", barcode)
             x = barcode.rect.left
             y = image_height - barcode.rect.top - barcode.rect.height
             h = barcode.rect.height
@@ -614,7 +616,7 @@ class Page:
                 w += 1
             value = barcode.data.decode("utf-8")
             self.barcodes.append({"x":x, "y":y, "height":h, "width":w, "value":value})
-            self.pixel_ignore_areas.append({"x": x, "y:": y, "height": h, "width": w})
+            self.pixel_ignore_areas.append({"x": x, "y": y, "height": h, "width": w})
 
     def _process_ignore_area(self, ignore_area: Dict):
         """Process each ignore area based on its type and convert it into pixel-based coordinates."""
@@ -771,7 +773,7 @@ class Page:
         
         try:
             unit = area.get('unit', 'px')
-        except:
+        except (AttributeError, TypeError):
             unit = 'px'
         area_x, area_y, area_w, area_h  = self._convert_to_pixels(area, unit)
 
@@ -1053,7 +1055,7 @@ class DocumentRepresentation:
     def __del__(self):  # pragma: no cover - defensive cleanup
         try:
             self.close()
-        except Exception:
+        except Exception:  # defensive: destructor must never raise
             pass
 
     def _load_pcl(self):
@@ -1066,7 +1068,7 @@ class DocumentRepresentation:
         import subprocess
         try:
             command = shutil.which('pcl6') or shutil.which('gpcl6win64') or shutil.which('gpcl6win32') or shutil.which('gpcl6')
-        except Exception:
+        except (OSError, TypeError):
             command = None
         if not command:
             raise AssertionError("No pcl6 executable found in path. Please install ghostPCL")
@@ -1095,12 +1097,12 @@ class DocumentRepresentation:
         ]
         subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
         toc = time.perf_counter()
-        print(f"Rendering pcl document to Image with ghostPCL performed in {toc - tic:0.4f} seconds")
+        logger.info("Rendering pcl document to Image with ghostPCL performed in %.4f seconds", toc - tic)
         tic = time.perf_counter()
         file_num =len(os.listdir(output_image_directory))
         for index in range(file_num):
             if (index == 0 or index == int(file_num-1)) and self.ignore_printfactory_envelope is True:
-                print("The printfactory envelope is ignored in page {}".format(index+1))
+                logger.info("The printfactory envelope is ignored in page %s", index+1)
                 continue
             else:
                 filename = 'output-' + str(index+1)+'.png'
@@ -1115,8 +1117,8 @@ class DocumentRepresentation:
                 self.pages.append(page)
 
         toc = time.perf_counter()
-        print(f"Conversion from Image to OpenCV Image performed in {toc - tic:0.4f} seconds")
-        shutil.rmtree(output_image_directory) 
+        logger.info("Conversion from Image to OpenCV Image performed in %.4f seconds", toc - tic)
+        shutil.rmtree(output_image_directory)
 
     def _load_ps(self):
         import subprocess
@@ -1127,7 +1129,7 @@ class DocumentRepresentation:
         from os.path import splitext, split 
         try:
             command = shutil.which('gs') or shutil.which('gswin64c') or shutil.which('gswin32c') or shutil.which('ghostscript')
-        except Exception:
+        except (OSError, TypeError):
             command = None
         if not command:
             raise AssertionError("No ghostscript executable found in path. Please install ghostscript")
@@ -1156,7 +1158,7 @@ class DocumentRepresentation:
         ]
         subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
         toc = time.perf_counter()
-        print(f"Rendering ps document to Image with ghostscript performed in {toc - tic:0.4f} seconds")
+        logger.info("Rendering ps document to Image with ghostscript performed in %.4f seconds", toc - tic)
         tic = time.perf_counter()
         file_num =len(os.listdir(output_image_directory))
         for index in range(file_num):
@@ -1170,7 +1172,7 @@ class DocumentRepresentation:
             self.pages.append(page)
         
         toc = time.perf_counter()
-        print(f"Conversion from Image to OpenCV Image performed in {toc - tic:0.4f} seconds")
+        logger.info("Conversion from Image to OpenCV Image performed in %.4f seconds", toc - tic)
         shutil.rmtree(output_image_directory)
 
     def get_barcodes(self):
@@ -1212,8 +1214,8 @@ class DocumentRepresentation:
                     page = pdf.load_page(page_num)
                     text_content += page.get_text("text")
                 return text_content if text_content.strip() else ""
-        except Exception as e:
-            print(f"Failed to extract text from PDF: {e}")
+        except Exception as e:  # defensive: covers ImportError, fitz internal errors, and I/O failures
+            logger.error("Failed to extract text from PDF: %s", e)
             return ""
 
     def compare_with(self, other_doc: 'DocumentRepresentation') -> bool:
@@ -1323,7 +1325,7 @@ class DocumentRepresentation:
         signatures = []
         try:
             widgets = page.widgets()
-        except Exception:
+        except Exception:  # defensive: PyMuPDF may raise varied errors on malformed PDFs
             widgets = []
         if not widgets:
             return signatures

--- a/DocTest/Downloader.py
+++ b/DocTest/Downloader.py
@@ -1,47 +1,167 @@
+import logging
 import os
+import re
 import tempfile
 import urllib.parse
 import urllib.request
 import uuid
 
+logger = logging.getLogger(__name__)
 
-def is_url(url):
+ALLOWED_SCHEMES = ("http", "https", "ftp")
+DEFAULT_MAX_SIZE = 100 * 1024 * 1024  # 100 MB
+
+
+def is_url(url, allowed_schemes=None):
     """
     Check if the provided string is a valid URL.
+
+    Args:
+        url: The string to check.
+        allowed_schemes: Optional tuple/list of allowed URL schemes.
+            If provided, the URL's scheme must be in this collection.
+            If None, any scheme with a netloc is accepted (backward compatible).
     """
     try:
         result = urllib.parse.urlparse(url)
-        return all([result.scheme, result.netloc])
-    except:
+        if not all([result.scheme, result.netloc]):
+            return False
+        if allowed_schemes is not None and result.scheme not in allowed_schemes:
+            return False
+        return True
+    except (ValueError, AttributeError):
         return False
 
 
-def download_file_from_url(url, directory=None, filename=None):
+def convert_github_blob_to_raw(url):
+    """
+    Convert a GitHub blob URL to a raw content URL.
+
+    For example:
+        https://github.com/user/repo/blob/main/path/file.png
+    becomes:
+        https://raw.githubusercontent.com/user/repo/main/path/file.png
+
+    If the URL is not a GitHub blob URL, returns the original URL unchanged.
+    """
+    pattern = r"^https?://github\.com/([^/]+)/([^/]+)/blob/(.+)$"
+    match = re.match(pattern, url)
+    if match:
+        user = match.group(1)
+        repo = match.group(2)
+        rest = match.group(3)
+        raw_url = f"https://raw.githubusercontent.com/{user}/{repo}/{rest}"
+        logger.info("Converted GitHub blob URL to raw URL: %s", raw_url)
+        return raw_url
+    return url
+
+
+def download_file_from_url(url, directory=None, filename=None, max_size=None):
     """
     Download the file from the url and save it in the provided directory.
     If directory is None, save it in a temp directory.
     Save the file with the provided filename.
-    If the filename is None, try to check if the URL contains a valid filename.
-    If the URL does not contain a filename, save it as a temporary filename by creating a uuid.
+    If the filename is None, derive a filename from the URL using a UUID
+    and the file extension from the URL path.
+    GitHub blob URLs are automatically converted to raw content URLs.
+
+    Args:
+        url: The URL to download the file from.
+        directory: The directory to save the file in. Defaults to temp dir.
+        filename: The filename to save the file as. Defaults to UUID + ext.
+        max_size: Maximum allowed file size in bytes. Defaults to
+            DEFAULT_MAX_SIZE (100 MB). If the downloaded file exceeds this
+            size, it is deleted and a ValueError is raised.
+
+    Raises:
+        ValueError: If the URL scheme is not in ALLOWED_SCHEMES or if the
+            downloaded file exceeds max_size.
     """
+    # Validate URL scheme
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ALLOWED_SCHEMES:
+        raise ValueError(
+            f"URL scheme '{parsed.scheme}' is not allowed. "
+            f"Allowed schemes: {', '.join(ALLOWED_SCHEMES)}"
+        )
+
+    if max_size is None:
+        max_size = DEFAULT_MAX_SIZE
+
     if directory is None:
         directory = tempfile.gettempdir()
     if filename is None:
-        filename = str(uuid.uuid4()) + "." + url.split(".")[-1]
+        _, ext = os.path.splitext(os.path.basename(parsed.path))
+        if ext:
+            filename = str(uuid.uuid4()) + ext
+        else:
+            logger.warning(
+                "Could not determine file extension from URL: %s", url
+            )
+            filename = str(uuid.uuid4())
     file_path = os.path.join(directory, filename)
-    urllib.request.urlretrieve(url, file_path)
+    download_url = convert_github_blob_to_raw(url)
+    urllib.request.urlretrieve(download_url, file_path)
+
+    # Validate downloaded file size
+    file_size = os.path.getsize(file_path)
+    if file_size > max_size:
+        os.remove(file_path)
+        raise ValueError(
+            f"Downloaded file size ({file_size} bytes) exceeds maximum "
+            f"allowed size ({max_size} bytes). File has been deleted."
+        )
+
+    # Sniff for HTML content when we likely expected a document/image
+    _warn_if_html_content(file_path, url)
+
     return file_path
+
+
+def _warn_if_html_content(file_path, url):
+    """
+    Check if the downloaded file appears to be HTML when we likely expected
+    something else (e.g., an image, PDF, or other binary document).
+
+    Logs a warning if HTML markers are detected but does not raise an error,
+    since the content could be legitimately HTML.
+    """
+    _, ext = os.path.splitext(file_path)
+    html_extensions = {".html", ".htm"}
+    if ext.lower() in html_extensions:
+        return  # HTML was expected, no warning needed
+
+    try:
+        with open(file_path, "rb") as f:
+            header = f.read(512)
+        # Look for common HTML markers in the first 512 bytes
+        header_lower = header.lstrip().lower()
+        if header_lower.startswith(b"<!doctype") or header_lower.startswith(
+            b"<html"
+        ):
+            logger.warning(
+                "Downloaded file from %s appears to contain HTML content "
+                "but was expected to be a different file type (extension: %s). "
+                "This may indicate a redirect to a login page or error page.",
+                url,
+                ext if ext else "(none)",
+            )
+    except OSError:
+        pass  # If we can't read the file for sniffing, skip the check
 
 
 def get_filename_from_url(url):
     """
     Check if the URL contains a valid filename.
     If the URL contains a valid filename, return the filename.
-    if the URL does not contain a filename, return None.
+    If the URL does not contain a filename, return None.
+
+    Uses proper URL parsing to strip query parameters and fragments.
     """
-    filename = None
-    if url is not None:
-        filename = url.split("/")[-1]
-        if "." not in filename:
-            filename = None
-    return filename
+    if not url:
+        return None
+    parsed = urllib.parse.urlparse(url)
+    basename = os.path.basename(parsed.path)
+    if not basename or "." not in basename:
+        return None
+    return basename

--- a/DocTest/IgnoreAreaManager.py
+++ b/DocTest/IgnoreAreaManager.py
@@ -1,9 +1,9 @@
 import json
-import re
-import sys
-import cv2
-from DocTest.config import DEFAULT_CONFIDENCE, MINIMUM_OCR_RESOLUTION
-from typing import List, Dict, Optional
+import logging
+from typing import List, Dict, Optional, Union
+
+logger = logging.getLogger(__name__)
+
 
 class IgnoreAreaManager:
     def __init__(self, ignore_area_file=None, mask=None):
@@ -26,19 +26,15 @@ class IgnoreAreaManager:
                 ignore_areas = [ignore_areas]
             return ignore_areas
         return []
-    
-    
+
     def _load_ignore_area_file(self):
         """Load ignore areas from the provided JSON file."""
         try:
             with open(self.ignore_area_file, 'r') as f:
                 return json.load(f)
         except IOError as err:
-            print(f"Ignore Area File {self.ignore_area_file} is not accessible.")
-            print(f"I/O error: {err}")
-        except Exception:
-            print("Unexpected error:", sys.exc_info()[0])
-            raise
+            logger.error("Ignore Area File %s is not accessible.", self.ignore_area_file)
+            logger.error("I/O error: %s", err)
 
     def _parse_mask(self):
         """Parse mask if provided as a string, dict, or list."""
@@ -54,76 +50,35 @@ class IgnoreAreaManager:
         """Parse a mask string that uses a custom format, e.g., 'top:10;bottom:10'."""
         ignore_areas = []
         mask_list = mask_str.split(';')
+        valid_locations = ('top', 'bottom', 'left', 'right')
         for mask in mask_list:
-            if mask:
-                location, percent = mask.split(':', 1)
-                if location in ['top', 'bottom', 'left', 'right'] and percent.isnumeric():
-                    ignore_areas.append({'page': 'all', 'type': 'area', 'location': location, 'percent': percent})
-                else:
-                    print(f'The mask {mask} is not valid. The percent value is not a number.')
+            if not mask:
+                continue
+            parts = mask.split(':', 1)
+            if len(parts) != 2:
+                logger.warning(
+                    "The mask '%s' is not valid. Expected format 'location:percent' "
+                    "(e.g., 'top:10').", mask
+                )
+                continue
+            location, percent = parts
+            if location not in valid_locations:
+                logger.warning(
+                    "The mask '%s' has an invalid location '%s'. "
+                    "Valid locations are: %s.",
+                    mask, location, ', '.join(valid_locations)
+                )
+                continue
+            if not percent.isnumeric():
+                logger.warning(
+                    "The mask '%s' is not valid. The percent value '%s' is not a number.",
+                    mask, percent
+                )
+                continue
+            ignore_areas.append({
+                'page': 'all',
+                'type': 'area',
+                'location': location,
+                'percent': percent,
+            })
         return ignore_areas
-
-    def _process_ignore_area(self, ignore_area, dpi, text_content):
-        """Process each ignore area based on its type and convert it into pixel-based coordinates."""
-        ignore_area_type = ignore_area.get('type')
-        
-        if ignore_area_type in ['pattern', 'line_pattern', 'word_pattern'] and text_content:
-            self._process_pattern_ignore_area(ignore_area, dpi, text_content)
-        elif ignore_area_type == 'coordinates':
-            self._process_coordinates_ignore_area(ignore_area, dpi)
-        elif ignore_area_type == 'area':
-            self._process_area_ignore_area(ignore_area, dpi)
-
-    def _process_pattern_ignore_area(self, ignore_area, dpi, text_content):
-        """Handle pattern-based ignore areas by searching the page for text patterns."""
-        pattern = ignore_area.get('pattern')
-        xoffset = int(ignore_area.get('xoffset', 0))
-        yoffset = int(ignore_area.get('yoffset', 0))
-
-        # Iterate through text data to identify matching patterns and mark as ignore areas
-        for i, page_text in enumerate(text_content):
-            n_boxes = len(page_text['text'])
-            for j in range(n_boxes):
-                if int(page_text.get('conf', [0])[j]) > DEFAULT_CONFIDENCE and re.match(pattern, page_text['text'][j]):
-                    x, y, w, h = page_text['left'][j], page_text['top'][j], page_text['width'][j], page_text['height'][j]
-                    pixel_factor = dpi / MINIMUM_OCR_RESOLUTION
-                    text_mask = {"page": i + 1, "x": int(x * pixel_factor) - xoffset, "y": int(y * pixel_factor) - yoffset,
-                                 "width": int(w * pixel_factor) + 2 * xoffset, "height": int(h * pixel_factor) + 2 * yoffset}
-                    self.ignore_areas.append(text_mask)
-
-    def _process_coordinates_ignore_area(self, ignore_area, dpi):
-        """Convert coordinate-based ignore areas into pixel-wise ignore areas."""
-        page = ignore_area.get('page', 'all')
-        unit = ignore_area.get('unit', 'px')
-        x, y, h, w = self._convert_to_pixels(ignore_area, unit, dpi)
-        self.ignore_areas.append({"page": page, "x": x, "y": y, "height": h, "width": w})
-
-    def _convert_to_pixels(self, ignore_area, unit, dpi):
-        """Convert dimensions from cm, mm, or px to pixel units."""
-        x, y, h, w = int(ignore_area['x']), int(ignore_area['y']), int(ignore_area['height']), int(ignore_area['width'])
-        if unit == 'mm':
-            constant = dpi / 25.4
-            x, y, h, w = int(x * constant), int(y * constant), int(h * constant), int(w * constant)
-        elif unit == 'cm':
-            constant = dpi / 2.54
-            x, y, h, w = int(x * constant), int(y * constant), int(h * constant), int(w * constant)
-        return x, y, h, w
-
-    def _process_area_ignore_area(self, ignore_area, dpi):
-        """Handle area-based ignore areas (e.g., 'top', 'bottom', 'left', 'right') as percentages."""
-        page = ignore_area.get('page', 'all')
-        location = ignore_area.get('location', None)
-        percent = int(ignore_area.get('percent', 10))
-        
-        # Assuming that opencv_images is accessible here
-        image_height = self.opencv_images[0].shape[0]  # Just for demo, need to handle for different pages
-        image_width = self.opencv_images[0].shape[1]
-
-        # Process based on location (top, bottom, left, right)
-        if location == 'top':
-            height = int(image_height * percent / 100)
-            self.ignore_areas.append({"page": page, "x": 0, "y": 0, "width": image_width, "height": height})
-        elif location == 'bottom':
-            height = int(image_height * percent / 100)
-            self.ignore_areas.append({"page": page, "x": 0, "y": image_height - height, "width": image_width, "height": height})
-        # Handle other locations (left, right)...

--- a/DocTest/Ocr.py
+++ b/DocTest/Ocr.py
@@ -1,3 +1,4 @@
+import logging
 import time
 import os
 import cv2
@@ -8,6 +9,8 @@ from pytesseract import Output
 import urllib
 import re
 import unicodedata
+
+logger = logging.getLogger(__name__)
 
 PYTESSERACT_CONFIDENCE=20
 
@@ -143,7 +146,7 @@ class EastTextExtractor:
         end = time.time()
 
         # show timing information on text prediction
-        print('[INFO] text detection took {:.6f} seconds'.format(end - start))
+        logger.info('text detection took %.6f seconds', end - start)
         return (scores, geometry)
 
     def _load_assets(self):
@@ -151,7 +154,7 @@ class EastTextExtractor:
         start = time.time()
         self.east_net = cv2.dnn.readNet(self.east)
         end = time.time()
-        print('[INFO] Loaded EAST text detector {:.6f} seconds ...'.format(end - start))
+        logger.info('Loaded EAST text detector %.6f seconds ...', end - start)
 
     def _get_east(self):
         if os.path.exists(self.east):
@@ -165,7 +168,7 @@ class EastTextExtractor:
         # check if file abs_east_model_path exists
         if os.path.isfile(data_file) is False:
             # Download from url https://raw.githubusercontent.com/oyyd/frozen_east_text_detection.pb/master/frozen_east_text_detection.pb
-            print("Downloading frozen_east_text_detection.pb from url")
+            logger.info("Downloading frozen_east_text_detection.pb from url")
             url = "https://raw.githubusercontent.com/oyyd/frozen_east_text_detection.pb/master/frozen_east_text_detection.pb"
             urllib.request.urlretrieve(url, data_file)
 

--- a/DocTest/PdfTest.py
+++ b/DocTest/PdfTest.py
@@ -1,7 +1,8 @@
+import logging
 from inspect import signature
-from pprint import pprint, pformat
+from pprint import pformat
 from deepdiff import DeepDiff
-from robot.api import logger
+from robot.api import logger as robot_logger
 from robot.api.deco import keyword, library
 import fitz
 import json
@@ -33,6 +34,8 @@ else:  # pragma: no cover - runtime fallback
     LLMDecisionLabel = Any  # type: ignore[misc, assignment]
 
 
+LOG = logging.getLogger(__name__)
+
 _PDF_LLM_RUNTIME: Optional[Tuple[Any, Any, Any]] = None
 
 
@@ -59,7 +62,7 @@ def _load_pdf_llm_runtime() -> Tuple[Any, Any, Any]:
     try:
         from DocTest.llm.client import assess_pdf_diff, create_binary_content
         from DocTest.llm.types import LLMDecisionLabel as _LLMDecisionLabel
-    except Exception as exc:  # pragma: no cover - optional dependency missing
+    except ImportError as exc:  # pragma: no cover - optional dependency missing
         raise LLMDependencyError() from exc
     _PDF_LLM_RUNTIME = (assess_pdf_diff, create_binary_content, _LLMDecisionLabel)
     return _PDF_LLM_RUNTIME
@@ -127,7 +130,7 @@ class PdfTest(object):
                 if isinstance(parsed, dict):
                     return parsed
             except json.JSONDecodeError:
-                logger.warn(f"Invalid character_replacements JSON: {value}")
+                robot_logger.warn(f"Invalid character_replacements JSON: {value}")
         return None
     
     @keyword
@@ -309,11 +312,11 @@ class PdfTest(object):
             text_mask_patterns_arg,
         )
         for warning in mask_warnings:
-            logger.warn(warning)
+            robot_logger.warn(warning)
 
         compiled_text_patterns, pattern_warnings = self._compile_text_mask_patterns(text_pattern_values)
         for warning in pattern_warnings:
-            logger.warn(warning)
+            robot_logger.warn(warning)
 
         mask_applied = bool(mask_file or mask_payload)
         llm_general_notes.append(f"mask_applied={'yes' if mask_applied else 'no'}")
@@ -360,8 +363,8 @@ class PdfTest(object):
             def _record_diff(facet: str, description: str, diff_payload: Any):
                 nonlocal differences_detected
                 differences_detected = True
-                print(description)
-                pprint(diff_payload, width=200)
+                robot_logger.info(description)
+                robot_logger.info(pformat(diff_payload, width=200))
                 llm_differences.append(
                     {
                         "facet": facet,
@@ -490,7 +493,7 @@ class PdfTest(object):
                         _load_pdf_llm_runtime()
                     )
                 except LLMDependencyError as exc:
-                    print(str(exc))
+                    robot_logger.warn(str(exc))
                 else:
                     llm_decision = self._handle_llm_for_pdf_differences(
                         reference_document=reference_document,
@@ -504,19 +507,18 @@ class PdfTest(object):
                     )
                 if llm_decision:
                     decision_value = _coerce_label_value(llm_decision.decision)
-                    print(
-                        f"LLM decision: {decision_value} "
-                        f"(confidence={llm_decision.confidence!r}) - {llm_decision.reason}"
+                    robot_logger.info(
+                        f"LLM decision: {decision_value} (confidence={llm_decision.confidence!r}) - {llm_decision.reason}"
                     )
                     if llm_decision.notes:
-                        print(f"LLM notes: {llm_decision.notes}")
+                        robot_logger.info(f"LLM notes: {llm_decision.notes}")
                     if llm_override_result and llm_decision.is_positive:
-                        print("LLM approved PDF differences. Overriding baseline failure.")
+                        robot_logger.info("LLM approved PDF differences. Overriding baseline failure.")
                         differences_detected = False
                     elif _decision_equals_flag(llm_decision.decision, llm_label_enum):
-                        print("LLM returned FLAG - keeping original PDF comparison result.")
+                        robot_logger.info("LLM returned FLAG - keeping original PDF comparison result.")
                     elif not llm_decision.is_positive and llm_override_result:
-                        print("LLM rejected PDF differences. Baseline failure will stand.")
+                        robot_logger.info("LLM rejected PDF differences. Baseline failure will stand.")
 
             if differences_detected:
                 raise AssertionError('The compared PDF Document Data is different.')
@@ -626,10 +628,10 @@ class PdfTest(object):
             text_mask_patterns_arg,
         )
         for warning in mask_warnings:
-            logger.warn(warning)
+            robot_logger.warn(warning)
         compiled_text_patterns, pattern_warnings = self._compile_text_mask_patterns(text_pattern_values)
         for warning in pattern_warnings:
-            logger.warn(warning)
+            robot_logger.warn(warning)
 
         reference_repr = DocumentRepresentation(
             reference_document,
@@ -694,10 +696,10 @@ class PdfTest(object):
             all_texts_were_found = False
             missing_text_list.append({'text':text_item, 'document':candidate_document})
         if all_texts_were_found is False:
-            print(missing_text_list)
+            robot_logger.info(f"Missing texts: {missing_text_list}")
             doc = None
             raise AssertionError('Some expected texts were not found in document')
-    
+
     @keyword
     def PDF_should_contain_strings(self, expected_text_list, candidate_document, **kwargs):
         """Checks if each item provided in the list ``expected_text_list`` appears in the PDF File ``candidate_document``.
@@ -748,13 +750,13 @@ class PdfTest(object):
             all_texts_were_found = False
             missing_text_list.append({'text':text_item, 'document':candidate_document})
         if all_texts_were_found is False:
-            print(f"Missing Texts:\n{missing_text_list}")
-            print(f"Found Texts:\n{found_text_list}")
+            robot_logger.info(f"Missing Texts:\n{missing_text_list}")
+            robot_logger.info(f"Found Texts:\n{found_text_list}")
             doc = None
             raise AssertionError('Some expected texts were not found in document')
         else:
             doc = None
-            print(f"Found Texts:\n{found_text_list}")
+            robot_logger.info(f"Found Texts:\n{found_text_list}")
 
     @keyword
     def PDF_should_not_contain_strings(self, expected_text_list, candidate_document, **kwargs):
@@ -803,14 +805,14 @@ class PdfTest(object):
             if text_item_found == False:
                 missing_text_list.append({'text':text_item, 'document':candidate_document})
         if found_text_list:
-            print(f"Missing Texts:\n{missing_text_list}")
-            print(f"Found Texts:\n{found_text_list}")
+            robot_logger.info(f"Missing Texts:\n{missing_text_list}")
+            robot_logger.info(f"Found Texts:\n{found_text_list}")
             doc = None
             raise AssertionError('Some non-expected texts were found in document')
         else:
             doc = None
-            print('None of the non-expected texts were found in document')
-            print(f"Missing Texts:\n{missing_text_list}")
+            robot_logger.info('None of the non-expected texts were found in document')
+            robot_logger.info(f"Missing Texts:\n{missing_text_list}")
     
     @keyword
     def compare_pdf_documents_with_llm(self, *args, llm_override: bool = False, **kwargs):
@@ -1068,7 +1070,7 @@ class PdfTest(object):
         individual differences as INFO (visible only within keyword output).
         """
         if result.passed:
-            logger.info("[PDF Structure] Documents match within configured tolerances.")
+            robot_logger.info("[PDF Structure] Documents match within configured tolerances.")
             return
 
         # Count total differences
@@ -1076,12 +1078,12 @@ class PdfTest(object):
         mode = "text-only (ignoring page boundaries)" if ignore_page_boundaries else "structure"
 
         # Single summary warning (appears at top of log.html)
-        logger.warn(f"[PDF Structure] Comparison failed: {diff_count} difference(s) found in {mode} comparison.")
+        robot_logger.warn(f"[PDF Structure] Comparison failed: {diff_count} difference(s) found in {mode} comparison.")
 
         # Log summary entries as INFO
         if result.summary:
             for entry in result.summary:
-                logger.info(f"[PDF Structure] {entry}")
+                robot_logger.info(f"[PDF Structure] {entry}")
 
         # Log page differences as INFO
         if result.page_differences:
@@ -1095,10 +1097,10 @@ class PdfTest(object):
                         details.append(f"candidate line={diff.candidate_index}")
                     if details:
                         message = f"{message} ({', '.join(details)})"
-                    logger.info(message)
+                    robot_logger.info(message)
                     if diff.deltas:
                         pretty = ", ".join(f"{axis}={value:.3f}" for axis, value in diff.deltas.items())
-                        logger.debug(f"[PDF Structure] Page {page} deltas: {pretty}")
+                        robot_logger.debug(f"[PDF Structure] Page {page} deltas: {pretty}")
 
         # Log document-level differences as INFO (for text-only mode)
         if result.document_differences:
@@ -1111,7 +1113,7 @@ class PdfTest(object):
                     details.append(f"candidate position={diff.cand_index}")
                 if details:
                     message = f"{message} ({', '.join(details)})"
-                logger.info(message)
+                robot_logger.info(message)
 
     def _ensure_local_document(self, document):
         return download_file_from_url(document) if is_url(document) else document
@@ -1133,19 +1135,19 @@ class PdfTest(object):
 
         try:
             settings = load_llm_settings(overrides)
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warn(f"Failed to load LLM settings: {exc}")
+        except Exception as exc:  # pragma: no cover - defensive: config parsing may raise varied errors
+            robot_logger.warn(f"Failed to load LLM settings: {exc}")
             return None
 
         if not settings.pdf_enabled:
-            print("LLM PDF evaluation requested but disabled via settings.")
+            robot_logger.info("LLM PDF evaluation requested but disabled via settings.")
             return None
 
         if create_binary_content_fn is None or assess_pdf_diff_fn is None:
             try:
                 default_assess, default_create, _ = _load_pdf_llm_runtime()
             except LLMDependencyError as exc:
-                print(str(exc))
+                robot_logger.warn(str(exc))
                 return None
             if assess_pdf_diff_fn is None:
                 assess_pdf_diff_fn = default_assess
@@ -1163,12 +1165,12 @@ class PdfTest(object):
                 create_binary_content_fn(reference_bytes, "application/pdf")
             )
         except FileNotFoundError:
-            logger.warn("Reference document not found for LLM attachment: %s", reference_document)
+            robot_logger.warn(f"Reference document not found for LLM attachment: {reference_document}")
         except LLMDependencyError as exc:
-            print(str(exc))
+            robot_logger.warn(str(exc))
             return None
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warn("Failed to attach reference document for LLM: %s", exc)
+        except Exception as exc:  # pragma: no cover - defensive: I/O or encoding errors from binary content creation
+            robot_logger.warn(f"Failed to attach reference document for LLM: {exc}")
 
         try:
             candidate_bytes = Path(candidate_document).read_bytes()
@@ -1176,12 +1178,12 @@ class PdfTest(object):
                 create_binary_content_fn(candidate_bytes, "application/pdf")
             )
         except FileNotFoundError:
-            logger.warn("Candidate document not found for LLM attachment: %s", candidate_document)
+            robot_logger.warn(f"Candidate document not found for LLM attachment: {candidate_document}")
         except LLMDependencyError as exc:
-            print(str(exc))
+            robot_logger.warn(str(exc))
             return None
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warn("Failed to attach candidate document for LLM: %s", exc)
+        except Exception as exc:  # pragma: no cover - defensive: I/O or encoding errors from binary content creation
+            robot_logger.warn(f"Failed to attach candidate document for LLM: {exc}")
 
         for item in differences:
             facet = item.get("facet", "unknown")
@@ -1205,10 +1207,10 @@ class PdfTest(object):
                 system_prompt=custom_prompt,
             )
         except LLMDependencyError as exc:
-            print(str(exc))
+            robot_logger.warn(str(exc))
             return None
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warn("LLM PDF evaluation failed: %s", exc)
+        except Exception as exc:  # pragma: no cover - defensive: LLM API may raise network/parsing/auth errors
+            robot_logger.warn(f"LLM PDF evaluation failed: {exc}")
             return None
         return decision
 

--- a/DocTest/PrintJobTests.py
+++ b/DocTest/PrintJobTests.py
@@ -1,10 +1,14 @@
+import logging
+from pprint import pformat
 from parsimonious.grammar import Grammar, NodeVisitor
 import re
 from pathlib import Path
-from pprint import pprint
 from deepdiff import DeepDiff
+from robot.api import logger as robot_logger
 from robot.api.deco import keyword, library, not_keyword
 from DocTest.Downloader import is_url, download_file_from_url
+
+logger = logging.getLogger(__name__)
 
 ROBOT_AUTO_KEYWORDS = False
 
@@ -145,11 +149,11 @@ class PostscriptVisitor(NodeVisitor):
         return [comment for comment in comments if comment!=None]
 
     def visit_document_trailer(self, node, visited_children):
-        _, comments = visited_children
-        for comment in comments:
-            if comment!=None:
-                self.trailer.append(comment)
-        return [comment for comment in comments if comment!=None]
+        _, items = visited_children
+        for item in items:
+            if isinstance(item, dict):
+                self.trailer.append(item)
+        return [item for item in items if isinstance(item, dict)]
 
     def generic_visit(self, node, visited_children):
         if not node.expr_name and node.children:
@@ -228,11 +232,11 @@ def get_postscript_print_job(filename):
     """
     grammar_postscript_commands = Grammar(
         r"""
-        file = header defaults? procedure_definitions document_setup pages+ document_trailer eof emptyline?
+        file = header defaults? procedure_definitions document_setup? pages+ document_trailer eof emptyline?
         header = header_start (comments/pjl_commands)* end_comments
         header_start = "%!PS-Adobe-3.0" linefeed
         comments = comment_type dataline
-        comment_type = title_comment / copyright_comment / creator_comment / creation_date_comment / bounding_box_comment / orientation_comment / pages_comment / document_needed_resources_comment / document_supplied_resources_comment / document_data_comment / language_level_comment
+        comment_type = title_comment / copyright_comment / creator_comment / creation_date_comment / bounding_box_comment / orientation_comment / pages_comment / document_needed_resources_comment / document_supplied_resources_comment / document_data_comment / language_level_comment / generic_dsc_comment
         title_comment = "%%Title:"
         copyright_comment = "%%Copyright:"
         creator_comment = "%%Creator:"
@@ -244,6 +248,7 @@ def get_postscript_print_job(filename):
         document_supplied_resources_comment = "%%DocumentSuppliedResources:"
         document_data_comment = "%%DocumentData:"
         language_level_comment = "%%LanguageLevel:"
+        generic_dsc_comment = ~r"%%[A-Za-z]+:"
         end_comments= "%%EndComments" linefeed
         pjl_commands = begin_pjl pjl_content*
         pjl_content = (pjl_prefix _ dataline)
@@ -276,7 +281,7 @@ def get_postscript_print_job(filename):
         page_setup = begin_page_setup dataline* feature* dataline* end_page_setup
         begin_page_setup = "%%BeginPageSetup"
         end_page_setup= "%%EndPageSetup" linefeed
-        document_trailer = trailer comments*
+        document_trailer = trailer (comments / dataline)*
         trailer = "%%Trailer" linefeed
         dataline = (!postscript_prefix anything linefeed) postscript_continue*
         anything = ~r".*"
@@ -359,15 +364,13 @@ def compare_print_jobs(type, reference_file, test_file):
 def compare_properties(reference_print_job, test_print_job):
     properties_are_equal = True
     list_difference = []
-    print("Reference File:")
-    pprint(reference_print_job.properties)
-    
-    print("\n")
-    print("Candidate File:")
-    pprint(test_print_job.properties)
-    
-    print("\n")
-    pprint(DeepDiff(reference_print_job.properties, test_print_job.properties, verbose_level=2))
+    robot_logger.info("Reference File:")
+    robot_logger.info(pformat(reference_print_job.properties))
+
+    robot_logger.info("Candidate File:")
+    robot_logger.info(pformat(test_print_job.properties))
+
+    robot_logger.info(pformat(DeepDiff(reference_print_job.properties, test_print_job.properties, verbose_level=2)))
     for reference_property_item in reference_print_job.properties:
         test_property_item = next((item for item in test_print_job.properties if item["property"] == reference_property_item["property"]), None)
         if reference_property_item['value']!=test_property_item['value']:
@@ -376,19 +379,13 @@ def compare_properties(reference_print_job, test_print_job):
             for x in reference_property_item['value']:
                 if x not in test_property_item['value']:
                     list_difference.append({'file':'reference', 'property':reference_property_item['property'], 'value':x})
-            
+
             for x in test_property_item['value']:
                 if x not in reference_property_item['value']:
                     list_difference.append({'file':'test', 'property':test_property_item['property'], 'value':x})
 
-            
-            
-            #print("Reference Property ", reference_property_item['property'], ":", reference_property_item['value'], " is not equal to ","Test Property ", test_property_item['property'], ":", test_property_item['value'])
     if properties_are_equal==False:
-        
-        pprint(list_difference)
-        print("\n")
-#        print(*list_difference, sep = "\n") 
+        robot_logger.info(pformat(list_difference))
         raise AssertionError('The compared print jobs are different.')
 
 @keyword
@@ -437,10 +434,7 @@ def check_print_job_property(print_job, property, value):
     if not test_property_item:
         raise AssertionError('The property does not exist:', property, value)
     if value not in test_property_item['value']:
-        print("Expected property: ", property, "\n\nExpected value:\n")
-        pprint(value)
-        print(" \nActual value:\n")
-        pprint(test_property_item['value'])
+        robot_logger.info(f"Expected property: {property}\n\nExpected value:\n{pformat(value)}\n\nActual value:\n{pformat(test_property_item['value'])}")
         raise AssertionError('The print job property check failed.')
 
 def printTable(myDict, colList=None):
@@ -456,4 +450,4 @@ def printTable(myDict, colList=None):
    colSize = [max(map(len,col)) for col in zip(*myList)]
    formatStr = ' | '.join(["{{:<{}}}".format(i) for i in colSize])
    myList.insert(1, ['-' * i for i in colSize]) # Seperating line
-   for item in myList: print(formatStr.format(*item))
+   for item in myList: robot_logger.info(formatStr.format(*item))

--- a/DocTest/VisualTest.py
+++ b/DocTest/VisualTest.py
@@ -9,6 +9,7 @@ import cv2
 import imutils
 import numpy as np
 from assertionengine import AssertionOperator, verify_assertion
+from robot.api import logger as robot_logger
 from robot.api.deco import keyword, library
 from robot.libraries.BuiltIn import BuiltIn
 
@@ -53,7 +54,7 @@ def _load_visual_llm_runtime() -> Tuple[Any, Any, Any]:
     try:
         from DocTest.llm.client import assess_visual_diff, create_binary_content
         from DocTest.llm.types import LLMDecisionLabel as _LLMDecisionLabel
-    except Exception as exc:  # pragma: no cover - optional dependency missing
+    except ImportError as exc:  # pragma: no cover - optional dependency missing
         raise LLMDependencyError() from exc
     _VISUAL_LLM_RUNTIME = (assess_visual_diff, create_binary_content, _LLMDecisionLabel)
     return _VISUAL_LLM_RUNTIME
@@ -189,8 +190,9 @@ class VisualTest:
             output_dir = built_in.get_variable_value("${OUTPUT DIR}")
             reference_run = built_in.get_variable_value("${REFERENCE_RUN}", False)
             pabot_index = built_in.get_variable_value("${PABOTQUEUEINDEX}")
-        except Exception:
-            print("Robot Framework is not running")
+        except (AttributeError, RuntimeError):
+            # RobotNotRunningError is an AttributeError subclass in Robot Framework
+            LOG.debug("Robot Framework is not running")
             return Path.cwd(), False, None
 
         if output_dir:
@@ -478,7 +480,7 @@ class VisualTest:
                             and (h * 25.4 / dpi < self.WATERMARK_HEIGHT)
                         ):
                             similar = True
-                            print("Visual differences are only in the watermark area.")
+                            robot_logger.info("Visual differences are only in the watermark area.")
 
                 if not similar and watermark_file:
                     if watermarks == []:
@@ -504,7 +506,7 @@ class VisualTest:
                             or cv2.countNonZero(cv2.subtract(thresh, mask_inv)) == 0
                         ):
                             similar = True
-                            print(
+                            robot_logger.info(
                                 "A watermark file was provided. After removing watermark area, both images are equal"
                             )
                             break
@@ -513,7 +515,7 @@ class VisualTest:
                     # try combining all watermark files by merging their areas
                     if not similar and len(watermarks) > 1:
                         try:
-                            print(
+                            robot_logger.info(
                                 f"Individual watermarks failed. Attempting to merge {len(watermarks)} watermark masks..."
                             )
 
@@ -541,7 +543,7 @@ class VisualTest:
                                 # Count pixels for debugging
                                 mask_pixels = np.sum(mask > 0)
                                 total_individual_pixels += mask_pixels
-                                print(f"  Watermark {i + 1}: {mask_pixels} white pixels")
+                                robot_logger.debug(f"  Watermark {i + 1}: {mask_pixels} white pixels")
 
                                 # Add debugging screenshot for individual watermarks
                                 if self.take_screenshots:
@@ -559,7 +561,7 @@ class VisualTest:
 
                             if combined_mask is not None:
                                 combined_black_pixels = np.sum(combined_mask == 0)
-                                print(
+                                robot_logger.debug(
                                     f"  Combined mask: {combined_black_pixels} black pixels (union of all comparison areas)"
                                 )
 
@@ -621,7 +623,7 @@ class VisualTest:
                                     == 0
                                 ):
                                     similar = True
-                                    print(
+                                    robot_logger.info(
                                         "Multiple watermark files were provided. After removing combined watermark areas, both images are equal"
                                     )
 
@@ -649,7 +651,7 @@ class VisualTest:
                                         combined_diff,
                                         suffix="_combined_watermark_diff_blend",
                                     )
-                        except Exception as e:
+                        except Exception as e:  # defensive: cv2 mask operations may raise varied errors
                             LOG.warning(f"Failed to combine watermark masks: {str(e)}")
 
                 if check_text_content and not similar:
@@ -685,17 +687,17 @@ class VisualTest:
                             # Add log message with the text content differences
                             # Add screenshots to the log of the reference and candidate areas
 
-                            print(
+                            robot_logger.info(
                                 f"Text content in the area {rect} differs:\n\nReference Text:\n{ref_area_text}\n\nCandidate Text:\n{cand_area_text}"
                             )
                         else:
                             page_notes.append(
                                 f"Rect {rect} visual change but identical text."
                             )
-                            print(
+                            robot_logger.info(
                                 f"Visual differences in the area {rect} but text content is the same."
                             )
-                            print(
+                            robot_logger.debug(
                                 f"Reference Text:\n{ref_area_text}\n\nCandidate Text:\n{cand_area_text}"
                             )
 
@@ -718,7 +720,7 @@ class VisualTest:
                         # If no words are fount, proceed with nornmal tolerance check and set check_pdf_content to False
                         if len(ref_words) == 0 or len(cand_words) == 0:
                             check_pdf_content = False
-                            print(
+                            robot_logger.info(
                                 "No pdf layout elements found. Proceeding with normal tolerance check."
                             )
 
@@ -810,7 +812,7 @@ class VisualTest:
                     # Flush buffered movement output (messages + screenshots) after overview
                     for entry in movement_output_buffer:
                         if entry[0] == "print":
-                            print(entry[1])
+                            robot_logger.info(entry[1])
                         elif entry[0] == "screenshot":
                             self.add_screenshot_to_log(
                                 entry[1], entry[2], original_size=entry[3]
@@ -839,7 +841,7 @@ class VisualTest:
                     # messages so they still appear in the Robot Framework log.
                     for entry in movement_output_buffer:
                         if entry[0] == "print":
-                            print(entry[1])
+                            robot_logger.info(entry[1])
 
             llm_decision = None
             llm_label_enum = None
@@ -855,7 +857,7 @@ class VisualTest:
                         _load_visual_llm_runtime()
                     )
                 except LLMDependencyError as exc:
-                    print(str(exc))
+                    robot_logger.warn(str(exc))
                 else:
                     llm_decision = self._handle_llm_for_visual_differences(
                         reference_image=reference_image,
@@ -870,25 +872,24 @@ class VisualTest:
 
                 if llm_decision:
                     decision_value = _coerce_label_value(llm_decision.decision)
-                    print(
-                        f"LLM decision: {decision_value} "
-                        f"(confidence={llm_decision.confidence!r}) - {llm_decision.reason}"
+                    robot_logger.info(
+                        f"LLM decision: {decision_value} (confidence={llm_decision.confidence!r}) - {llm_decision.reason}"
                     )
                     if llm_decision.notes:
-                        print(f"LLM notes: {llm_decision.notes}")
+                        robot_logger.info(f"LLM notes: {llm_decision.notes}")
                     if llm_override_result and llm_decision.is_positive:
-                        print("LLM approved differences. Overriding baseline failure.")
+                        robot_logger.info("LLM approved differences. Overriding baseline failure.")
                         detected_differences = []
                     elif _decision_equals_flag(llm_decision.decision, llm_label_enum):
-                        print("LLM returned FLAG - keeping original comparison result.")
+                        robot_logger.info("LLM returned FLAG - keeping original comparison result.")
                     elif not llm_decision.is_positive and llm_override_result:
-                        print("LLM rejected differences. Baseline failure will be raised.")
+                        robot_logger.info("LLM rejected differences. Baseline failure will be raised.")
 
             for diff in detected_differences:
-                print(diff["message"])
+                robot_logger.info(diff["message"])
                 self._raise_comparison_failure()
 
-            print("Images/Document comparison passed.")
+            robot_logger.info("Images/Document comparison passed.")
         finally:
             reference_doc.close()
             candidate_doc.close()
@@ -928,19 +929,19 @@ class VisualTest:
 
         try:
             settings = load_llm_settings(overrides)
-        except Exception as exc:  # pragma: no cover - defensive
+        except Exception as exc:  # pragma: no cover - defensive: config parsing may raise varied errors
             LOG.warning("Failed to load LLM settings: %s", exc)
             return None
 
         if not settings.visual_enabled:
-            print("LLM visual evaluation requested but disabled via settings.")
+            robot_logger.info("LLM visual evaluation requested but disabled via settings.")
             return None
 
         if create_binary_content_fn is None or assess_visual_diff_fn is None:
             try:
                 default_assess, default_create, _ = _load_visual_llm_runtime()
             except LLMDependencyError as exc:
-                print(str(exc))
+                robot_logger.warn(str(exc))
                 return None
             if assess_visual_diff_fn is None:
                 assess_visual_diff_fn = default_assess
@@ -982,10 +983,10 @@ class VisualTest:
                         )
                     )
         except LLMDependencyError as exc:
-            print(str(exc))
+            robot_logger.warn(str(exc))
             return None
-        except Exception as exc:  # pragma: no cover - defensive
-            print(f"Failed to prepare LLM payload: {exc}")
+        except Exception as exc:  # pragma: no cover - defensive: image encoding or content creation may fail
+            LOG.warning("Failed to prepare LLM payload: %s", exc)
             return None
 
         try:
@@ -997,10 +998,10 @@ class VisualTest:
                 system_prompt=custom_prompt,
             )
         except LLMDependencyError as exc:
-            print(str(exc))
+            robot_logger.warn(str(exc))
             return None
-        except Exception as exc:  # pragma: no cover - defensive
-            print(f"LLM evaluation failed: {exc}")
+        except Exception as exc:  # pragma: no cover - defensive: LLM API may raise network/parsing/auth errors
+            LOG.warning("LLM evaluation failed: %s", exc)
             return None
         return decision
 
@@ -1022,7 +1023,7 @@ class VisualTest:
         output_buffer: list = None,
     ) -> bool:
         if not diff_rectangles:
-            print("No difference areas detected for movement tolerance check.")
+            robot_logger.info("No difference areas detected for movement tolerance check.")
             return True
 
         def _log_screenshot(image, suffix, original_size=False):
@@ -1035,7 +1036,7 @@ class VisualTest:
             if output_buffer is not None:
                 output_buffer.append(("print", msg))
             else:
-                print(msg)
+                robot_logger.info(msg)
 
         failed_areas = []
         prefer_pdf = use_pdf_content or (
@@ -1279,7 +1280,7 @@ class VisualTest:
         output_buffer: list = None,
     ) -> bool:
         if not diff_rectangles:
-            print("No difference areas detected for movement tolerance check.")
+            robot_logger.info("No difference areas detected for movement tolerance check.")
             return True
 
         def _log_screenshot(image, suffix, original_size=False):
@@ -1292,7 +1293,7 @@ class VisualTest:
             if output_buffer is not None:
                 output_buffer.append(("print", msg))
             else:
-                print(msg)
+                robot_logger.info(msg)
 
         failed_areas = []
         fallback_detections = 0
@@ -1352,7 +1353,7 @@ class VisualTest:
                         suffix="_moved_area",
                         original_size=False,
                     )
-            except Exception as exc:
+            except Exception as exc:  # defensive: cv2/numpy operations on image areas may raise varied errors
                 _log_message(f"Could not compare areas: {exc}")
                 failed_areas.append((rect, f"error: {str(exc)}"))
                 _log_screenshot(
@@ -1411,7 +1412,7 @@ class VisualTest:
                 f"Supported values are: {', '.join(sorted(self.MOVEMENT_DETECTION_METHODS))}."
             )
         self.movement_detection = method
-        print(f"Movement detection method set to '{method}'.")
+        robot_logger.info(f"Movement detection method set to '{method}'.")
 
     @keyword
     def get_text_from_area(
@@ -1815,8 +1816,8 @@ class VisualTest:
         original_template = DocumentRepresentation(template).pages[0].image
 
         # Log original dimensions for debugging
-        print(f"Original template dimensions: {original_template.shape}")
-        print(f"Original image dimensions: {img.shape}")
+        robot_logger.debug(f"Original template dimensions: {original_template.shape}")
+        robot_logger.debug(f"Original image dimensions: {img.shape}")
 
         # Crop the template image if crop boundaries are provided
         if all_crop_args:
@@ -1838,7 +1839,7 @@ class VisualTest:
             template = original_template[
                 tpl_crop_y1:tpl_crop_y2, tpl_crop_x1:tpl_crop_x2
             ].copy()
-            print(f"Cropped template dimensions: {template.shape}")
+            robot_logger.debug(f"Cropped template dimensions: {template.shape}")
         else:
             template = original_template
 
@@ -1861,17 +1862,17 @@ class VisualTest:
             )
 
         if detection == "template":
-            print(f"Using template matching with threshold: {threshold}")
+            robot_logger.debug(f"Using template matching with threshold: {threshold}")
 
             # Perform template matching
             res = cv2.matchTemplate(img_gray, template_gray, cv2.TM_SQDIFF_NORMED)
             min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)
 
             # Log matching results for debugging
-            print(
+            robot_logger.debug(
                 f"Template matching results - min_val: {min_val:.6f}, max_val: {max_val:.6f}"
             )
-            print(f"Best match location: {min_loc}")
+            robot_logger.debug(f"Best match location: {min_loc}")
 
             top_left = min_loc
             bottom_right = (top_left[0] + w, top_left[1] + h)
@@ -1881,7 +1882,7 @@ class VisualTest:
             match = min_val <= threshold
 
             if match:
-                print(
+                robot_logger.info(
                     f"Template found at location: {top_left} with confidence: {1.0 - min_val:.6f}"
                 )
                 # Draw rectangle on a copy to avoid modifying original
@@ -1891,7 +1892,7 @@ class VisualTest:
                 if take_screenshots:
                     self.add_screenshot_to_log(img_result, "image_with_template")
             else:
-                print(
+                robot_logger.info(
                     f"Template not found. Best match confidence: {1.0 - min_val:.6f}, required: {1.0 - threshold:.6f}"
                 )
                 if take_screenshots:
@@ -2099,16 +2100,16 @@ class VisualTest:
                     ".jpg", image, [int(cv2.IMWRITE_JPEG_QUALITY), 70]
                 )  # im_arr: image in Numpy one-dim array format.
                 im_b64 = base64.b64encode(encoded_img).decode()
-                print(
-                    "*HTML* "
-                    + f'{suffix}:<br><img alt="screenshot" src="data:image/jpeg;base64,{im_b64}" style="{img_style}">'
+                robot_logger.info(
+                    f'{suffix}:<br><img alt="screenshot" src="data:image/jpeg;base64,{im_b64}" style="{img_style}">',
+                    html=True,
                 )
             else:
                 _, encoded_img = cv2.imencode(".png", image)
                 im_b64 = base64.b64encode(encoded_img).decode()
-                print(
-                    "*HTML* "
-                    + f'{suffix}:<br><img alt="screenshot" src="data:image/png;base64,{im_b64}" style="{img_style}">'
+                robot_logger.info(
+                    f'{suffix}:<br><img alt="screenshot" src="data:image/png;base64,{im_b64}" style="{img_style}">',
+                    html=True,
                 )
         else:
             screenshot_name = str(
@@ -2131,9 +2132,9 @@ class VisualTest:
                 )
             else:
                 cv2.imwrite(abs_screenshot_path, image)
-            print(
-                "*HTML* "
-                + f'{suffix}:<br><a href="{rel_screenshot_path}" target="_blank"><img src="{rel_screenshot_path}" style="{img_style}"></a>'
+            robot_logger.info(
+                f'{suffix}:<br><a href="{rel_screenshot_path}" target="_blank"><img src="{rel_screenshot_path}" style="{img_style}"></a>',
+                html=True,
             )
 
     def find_partial_image_position(
@@ -2224,7 +2225,7 @@ class VisualTest:
                         )
                     return result
 
-            except Exception as e:
+            except Exception as e:  # defensive: catch any error to try next detection method
                 self._log_verbose_warning(
                     f"Movement detection failed with {method} method: {str(e)}"
                 )
@@ -2308,7 +2309,7 @@ class VisualTest:
                         edgeThreshold=edge_threshold,
                         nfeatures=1000,
                     )
-                except Exception:
+                except Exception:  # defensive: cv2 may reject parameter combinations
                     # Fallback to basic SIFT if parameterized version fails
                     return cv2.SIFT_create()
 
@@ -2347,7 +2348,7 @@ class VisualTest:
                     ):
                         break
 
-                except Exception as e:
+                except Exception as e:  # defensive: catch any cv2 error to try next parameter set
                     self._log_verbose_warning(
                         f"SIFT: Failed with parameters ({contrast_thresh}, {edge_thresh}): {str(e)}"
                     )
@@ -2398,7 +2399,7 @@ class VisualTest:
                         else []
                     )
 
-                except Exception as e:
+                except Exception as e:  # defensive: cv2 FLANN matching may raise varied errors
                     self._log_verbose_warning(
                         f"SIFT: Matching failed: {str(e)}"
                     )
@@ -2467,7 +2468,7 @@ class VisualTest:
                                 ):  # At least 15% inliers (reduced for text)
                                     break
                         M = None  # Reset if validation failed
-                    except Exception as e:
+                    except Exception as e:  # defensive: catch any error to try next RANSAC config
                         self._log_verbose_warning(
                             f"SIFT: Homography computation failed with config {ransac_thresholds.index(ransac_thresh)}: {str(e)}"
                         )
@@ -2506,13 +2507,13 @@ class VisualTest:
                     "method": "sift",
                 }
 
-            except Exception as e:
+            except Exception as e:  # defensive: homography computation involves complex numpy/cv2 ops
                 self._log_verbose_warning(
                     f"SIFT: Homography computation failed: {str(e)}"
                 )
                 return None
 
-        except Exception as e:
+        except Exception as e:  # defensive: outermost safety net for entire SIFT pipeline
             LOG.error(f"SIFT: Unexpected error in movement detection: {str(e)}")
             return None
 
@@ -2554,7 +2555,7 @@ class VisualTest:
 
             return True
 
-        except Exception:
+        except Exception:  # defensive: validation must not crash on malformed input
             return False
 
     def find_partial_image_distance_with_matchtemplate(
@@ -2652,7 +2653,7 @@ class VisualTest:
                 cnts, hierarchy = cv2.findContours(
                     mask.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
                 )
-            except Exception as e:
+            except Exception as e:  # defensive: cv2 contour detection may fail on unusual masks
                 self._log_verbose_warning(
                     f"Template matching: Contour detection failed: {str(e)}"
                 )
@@ -2784,7 +2785,7 @@ class VisualTest:
                             results.append(
                                 (1 - max_val, max_loc, method)
                             )  # Convert to distance-like metric
-                    except Exception as e:
+                    except Exception as e:  # defensive: catch any error to try next matching method
                         self._log_verbose_warning(
                             f"Template matching method {method} failed: {str(e)}"
                         )
@@ -2849,7 +2850,7 @@ class VisualTest:
                 )
                 return None
 
-        except Exception as e:
+        except Exception as e:  # defensive: outermost safety net for entire template matching pipeline
             LOG.error(f"Template matching: Unexpected error: {str(e)}")
             return None
 
@@ -2890,7 +2891,7 @@ class VisualTest:
                         scaleFactor=1.2,
                         nlevels=8,
                     )
-                except Exception as e:
+                except Exception as e:  # defensive: cv2 may reject ORB parameter combinations
                     self._log_verbose_warning(
                         f"ORB keypoints: Failed to create detector: {str(e)}"
                     )
@@ -2904,7 +2905,7 @@ class VisualTest:
             try:
                 img1_kp, img1_des = orb.detectAndCompute(img1, None)
                 img2_kp, img2_des = orb.detectAndCompute(img2, None)
-            except Exception as e:
+            except Exception as e:  # defensive: cv2 detectAndCompute may fail on degenerate images
                 self._log_verbose_warning(
                     f"ORB keypoints: Detection failed: {str(e)}"
                 )
@@ -2937,7 +2938,7 @@ class VisualTest:
 
             return img1_kp, img1_des, img2_kp, img2_des
 
-        except Exception as e:
+        except Exception as e:  # defensive: outermost safety net for ORB keypoint pipeline
             LOG.error(f"ORB keypoints: Unexpected error: {str(e)}")
             return None, None, None, None
 
@@ -2986,7 +2987,7 @@ class VisualTest:
                     ):
                         return img1_kp, img1_des, img2_kp, img2_des
 
-                except Exception as e:
+                except Exception as e:  # defensive: catch any error to try next SIFT config
                     self._log_verbose_warning(
                         f"SIFT keypoints: Config {config} failed: {str(e)}"
                     )
@@ -2995,7 +2996,7 @@ class VisualTest:
             self._log_verbose_warning("SIFT keypoints: All configurations failed")
             return None, None, None, None
 
-        except Exception as e:
+        except Exception as e:  # defensive: outermost safety net for SIFT keypoint pipeline
             LOG.error(f"SIFT keypoints: Unexpected error: {str(e)}")
             return None, None, None, None
 
@@ -3076,7 +3077,7 @@ class VisualTest:
                 cnts, hierarchy = cv2.findContours(
                     mask.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
                 )
-            except Exception as e:
+            except Exception as e:  # defensive: cv2 contour detection may fail on unusual masks
                 self._log_verbose_warning(
                     f"ORB: Contour detection failed: {str(e)}"
                 )
@@ -3198,7 +3199,7 @@ class VisualTest:
                         ):
                             return template_kp, template_des, img_kp, img_des
 
-                    except Exception as e:
+                    except Exception as e:  # defensive: catch any error to try next ORB config
                         self._log_verbose_warning(
                             f"ORB: Configuration {orb_configs.index((nfeatures, edge_thresh, patch_size))} failed: {str(e)}"
                         )
@@ -3260,7 +3261,7 @@ class VisualTest:
 
                     return good_matches
 
-                except Exception as e:
+                except Exception as e:  # defensive: cv2 BFMatcher may raise varied errors
                     self._log_verbose_warning(f"ORB: Matching failed: {str(e)}")
                     return []
 
@@ -3323,7 +3324,7 @@ class VisualTest:
                                 best_homography = M
                                 best_inlier_ratio = inlier_ratio
 
-                    except Exception as e:
+                    except Exception as e:  # defensive: catch any error to try next RANSAC config
                         self._log_verbose_warning(
                             f"ORB: Homography computation failed with config {ransac_configs.index((ransac_thresh, max_iters, confidence))}: {str(e)}"
                         )
@@ -3365,7 +3366,7 @@ class VisualTest:
                             flags=cv2.DRAW_MATCHES_FLAGS_NOT_DRAW_SINGLE_POINTS,
                         )
                         self.add_screenshot_to_log(match_img, "ORB_matches")
-                    except Exception as e:
+                    except Exception as e:  # defensive: visualization is non-critical
                         self._log_verbose_warning(
                             f"ORB: Could not create match visualization: {str(e)}"
                         )
@@ -3379,13 +3380,13 @@ class VisualTest:
                     "method": "orb",
                 }
 
-            except Exception as e:
+            except Exception as e:  # defensive: homography computation involves complex numpy/cv2 ops
                 self._log_verbose_warning(
                     f"ORB: Error in homography computation: {str(e)}"
                 )
                 return None
 
-        except Exception as e:
+        except Exception as e:  # defensive: outermost safety net for entire ORB movement pipeline
             LOG.error(f"ORB: Unexpected error in movement detection: {str(e)}")
             return None
 
@@ -3454,8 +3455,8 @@ class VisualTest:
 
             return True
 
-        except Exception as e:
-            print(f"Error validating bounding box: {e}")
+        except Exception as e:  # defensive: validation must not crash on malformed input
+            LOG.warning("Error validating bounding box: %s", e)
             return False
 
         # Ensure the width and height are approximately consistent (not too skewed)
@@ -3694,7 +3695,7 @@ class VisualTest:
 
             return True
 
-        except Exception as e:
+        except Exception as e:  # defensive: validation must not crash on malformed result dict
             self._log_verbose_warning(
                 f"Error validating movement result: {str(e)}"
             )
@@ -3757,7 +3758,7 @@ class VisualTest:
                             f"No valid image files found in watermark directory: {watermark_file}"
                         )
                         return []
-                except Exception as e:
+                except OSError as e:
                     LOG.error(
                         f"Error reading watermark directory {watermark_file}: {str(e)}"
                     )
@@ -3800,7 +3801,7 @@ class VisualTest:
                             # Log mask statistics for debugging
                             mask_pixels = np.sum(mask > 0)
                             content_ratio = mask_pixels / watermark_gray.size
-                            print(
+                            robot_logger.debug(
                                 f"  Watermark mask: {mask_pixels} white pixels ({content_ratio:.1%})"
                             )
 
@@ -3813,7 +3814,7 @@ class VisualTest:
                                 f"Could not create valid mask for watermark: {single_watermark}"
                             )
 
-                    except Exception as e:
+                    except Exception as e:  # defensive: file loading + image processing may fail in various ways
                         LOG.warning(
                             f"Watermark file {single_watermark} could not be loaded: {str(e)}"
                         )

--- a/utest/test_barcode.py
+++ b/utest/test_barcode.py
@@ -3,12 +3,14 @@ import pytest
 from pathlib import Path
 import numpy
 
+IGNORE_AREA_REQUIRED_KEYS = {"x", "y", "height", "width"}
+
 def test_single_png_with_barcode(testdata_dir):
     img = DocumentRepresentation(testdata_dir / 'datamatrix.png', contains_barcodes=True)
     assert len(img.get_barcodes()) == 2
     assert len(img.pages[0].barcodes) == 2
     assert len(img.pages[0].pixel_ignore_areas) == 2
-    
+
 
 def test_single_pdf_with_barcode(testdata_dir):
     img = DocumentRepresentation(testdata_dir / 'sample_1_page_with_barcodes.pdf', contains_barcodes=True)
@@ -27,3 +29,53 @@ def test_barcode_sample_page(testdata_dir):
     assert len(img.get_barcodes()) == 12
     assert len(img.pages[0].barcodes) == 12
     assert len(img.pages[0].pixel_ignore_areas) == 12
+
+def test_ignore_area_schema_for_datamatrix(testdata_dir):
+    """Verify that datamatrix ignore areas have the correct keys (x, y, height, width)."""
+    img = DocumentRepresentation(testdata_dir / 'datamatrix.png', contains_barcodes=True)
+    for area in img.pages[0].pixel_ignore_areas:
+        assert set(area.keys()) == IGNORE_AREA_REQUIRED_KEYS, (
+            f"Ignore area has wrong keys: {set(area.keys())}. "
+            f"Expected: {IGNORE_AREA_REQUIRED_KEYS}"
+        )
+
+def test_ignore_area_schema_for_zbar_barcodes(testdata_dir):
+    """Verify that zbar barcode ignore areas have the correct keys."""
+    img = DocumentRepresentation(testdata_dir / 'sample_1_page_with_barcodes.pdf', contains_barcodes=True)
+    for area in img.pages[0].pixel_ignore_areas:
+        assert set(area.keys()) == IGNORE_AREA_REQUIRED_KEYS, (
+            f"Ignore area has wrong keys: {set(area.keys())}. "
+            f"Expected: {IGNORE_AREA_REQUIRED_KEYS}"
+        )
+
+def test_ignore_area_coordinates_are_integers(testdata_dir):
+    """Verify that all ignore area coordinates are integers."""
+    img = DocumentRepresentation(testdata_dir / 'datamatrix.png', contains_barcodes=True)
+    for area in img.pages[0].pixel_ignore_areas:
+        for key in IGNORE_AREA_REQUIRED_KEYS:
+            assert isinstance(area[key], int), (
+                f"Ignore area key '{key}' should be int, got {type(area[key]).__name__}"
+            )
+
+def test_get_image_with_ignore_areas_does_not_crash_datamatrix(testdata_dir):
+    """Regression test: get_image_with_ignore_areas must not crash when datamatrices are detected.
+
+    Before the fix, identify_datamatrices() stored the key "y:" instead of "y",
+    causing a TypeError in get_image_with_ignore_areas() when it tried arithmetic
+    on None.
+    """
+    img = DocumentRepresentation(testdata_dir / 'datamatrix.png', contains_barcodes=True)
+    page = img.pages[0]
+    assert len(page.pixel_ignore_areas) > 0, "Expected at least one ignore area"
+    result = page.get_image_with_ignore_areas()
+    assert result is not None
+    assert result.shape == page.image.shape
+
+def test_get_image_with_ignore_areas_does_not_crash_zbar(testdata_dir):
+    """Verify get_image_with_ignore_areas works for zbar-detected barcodes too."""
+    img = DocumentRepresentation(testdata_dir / 'sample_1_page_with_barcodes.pdf', contains_barcodes=True)
+    page = img.pages[0]
+    assert len(page.pixel_ignore_areas) > 0, "Expected at least one ignore area"
+    result = page.get_image_with_ignore_areas()
+    assert result is not None
+    assert result.shape == page.image.shape

--- a/utest/test_benchmarks.py
+++ b/utest/test_benchmarks.py
@@ -1,0 +1,157 @@
+"""Resource benchmarks for document loading and comparison.
+
+These tests verify that core operations complete within reasonable time
+bounds and that resources are properly released after use.
+"""
+
+import gc
+import time
+import weakref
+
+import pytest
+
+from DocTest.DocumentRepresentation import DocumentRepresentation
+from DocTest.VisualTest import VisualTest
+
+
+# ---------------------------------------------------------------------------
+# Image loading
+# ---------------------------------------------------------------------------
+
+
+def test_image_load_performance(testdata_dir):
+    """Loading a single PNG image should complete in under 2 seconds."""
+    start = time.time()
+    doc = DocumentRepresentation(str(testdata_dir / "birthday_left.png"))
+    elapsed = time.time() - start
+    assert elapsed < 2.0, f"Image loading took {elapsed:.2f}s, expected < 2s"
+    assert doc.page_count == 1
+    doc.close()
+
+
+def test_large_image_load_performance(testdata_dir):
+    """Loading a larger image (1080p birthday) should complete in under 3 seconds."""
+    start = time.time()
+    doc = DocumentRepresentation(str(testdata_dir / "birthday_1080.png"))
+    elapsed = time.time() - start
+    assert elapsed < 3.0, f"Large image loading took {elapsed:.2f}s, expected < 3s"
+    assert doc.page_count == 1
+    doc.close()
+
+
+# ---------------------------------------------------------------------------
+# PDF loading
+# ---------------------------------------------------------------------------
+
+
+def test_pdf_single_page_load_performance(testdata_dir):
+    """Loading a single-page PDF should complete in under 5 seconds."""
+    start = time.time()
+    doc = DocumentRepresentation(str(testdata_dir / "sample_1_page.pdf"))
+    elapsed = time.time() - start
+    assert elapsed < 5.0, f"PDF loading took {elapsed:.2f}s, expected < 5s"
+    assert doc.page_count == 1
+    doc.close()
+
+
+def test_pdf_multi_page_load_performance(testdata_dir):
+    """Loading a multi-page PDF should complete in under 10 seconds."""
+    start = time.time()
+    doc = DocumentRepresentation(str(testdata_dir / "sample.pdf"))
+    elapsed = time.time() - start
+    assert elapsed < 10.0, f"Multi-page PDF loading took {elapsed:.2f}s, expected < 10s"
+    assert doc.page_count >= 1
+    doc.close()
+
+
+# ---------------------------------------------------------------------------
+# Comparison benchmarks
+# ---------------------------------------------------------------------------
+
+
+def test_identical_image_comparison_performance(testdata_dir):
+    """Comparing two identical images should complete in under 5 seconds."""
+    vt = VisualTest()
+    ref = str(testdata_dir / "birthday_left.png")
+
+    start = time.time()
+    vt.compare_images(ref, ref)
+    elapsed = time.time() - start
+
+    assert elapsed < 5.0, f"Identical image comparison took {elapsed:.2f}s, expected < 5s"
+
+
+def test_different_image_comparison_performance(testdata_dir):
+    """Comparing two different images should complete in under 5 seconds (excluding error)."""
+    vt = VisualTest()
+    ref = str(testdata_dir / "birthday_left.png")
+    cand = str(testdata_dir / "birthday_right.png")
+
+    start = time.time()
+    with pytest.raises(AssertionError):
+        vt.compare_images(ref, cand)
+    elapsed = time.time() - start
+
+    assert elapsed < 5.0, f"Different image comparison took {elapsed:.2f}s, expected < 5s"
+
+
+def test_pdf_comparison_performance(testdata_dir):
+    """Comparing two single-page PDFs should complete in under 10 seconds."""
+    vt = VisualTest()
+    ref = str(testdata_dir / "sample_1_page.pdf")
+
+    start = time.time()
+    vt.compare_images(ref, ref)
+    elapsed = time.time() - start
+
+    assert elapsed < 10.0, f"PDF comparison took {elapsed:.2f}s, expected < 10s"
+
+
+# ---------------------------------------------------------------------------
+# Memory / resource cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_document_representation_gc_after_close(testdata_dir):
+    """After close(), the DocumentRepresentation should be garbage-collectible."""
+    doc = DocumentRepresentation(str(testdata_dir / "birthday_left.png"))
+    ref = weakref.ref(doc)
+    doc.close()
+    del doc
+    gc.collect()
+    assert ref() is None, "DocumentRepresentation was not garbage collected after close()"
+
+
+def test_pdf_document_gc_after_close(testdata_dir):
+    """After close(), a PDF DocumentRepresentation should be garbage-collectible."""
+    doc = DocumentRepresentation(str(testdata_dir / "sample_1_page.pdf"))
+    ref = weakref.ref(doc)
+    doc.close()
+    del doc
+    gc.collect()
+    assert ref() is None, "PDF DocumentRepresentation was not garbage collected after close()"
+
+
+def test_multiple_loads_no_resource_leak(testdata_dir):
+    """Loading and closing multiple documents should not leak memory significantly."""
+    gc.collect()
+
+    for _ in range(5):
+        doc = DocumentRepresentation(str(testdata_dir / "birthday_left.png"))
+        assert doc.page_count == 1
+        doc.close()
+
+    gc.collect()
+    # If we get here without OOM or errors, the test passes.
+    # This is a smoke test for gross resource leaks.
+
+
+def test_page_data_accessible_before_close(testdata_dir):
+    """Verify that page data is accessible before close and not after."""
+    doc = DocumentRepresentation(str(testdata_dir / "birthday_left.png"))
+    assert doc.page_count == 1
+    assert doc.pages[0].image is not None
+    doc.close()
+    # After close, pages list should be empty or image should be cleaned up
+    # This is a basic sanity check -- the exact behavior depends on implementation
+    assert doc is not None  # Object still exists, just resources released

--- a/utest/test_capability_check.py
+++ b/utest/test_capability_check.py
@@ -1,0 +1,289 @@
+"""Tests for DocTest.CapabilityCheck module."""
+
+import importlib
+import sys
+
+import pytest
+
+from DocTest.CapabilityCheck import (
+    CAPABILITY_REGISTRY,
+    PYTHON_PACKAGE_REGISTRY,
+    CapabilityCheck,
+    check_all_capabilities,
+    check_binary,
+    check_python_package,
+    format_capability_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_binary
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBinary:
+    def test_returns_path_when_binary_exists(self, monkeypatch):
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", lambda name: f"/usr/bin/{name}")
+        assert check_binary("tesseract") == "/usr/bin/tesseract"
+
+    def test_returns_none_when_binary_missing(self, monkeypatch):
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", lambda name: None)
+        assert check_binary("tesseract") is None
+
+    def test_returns_none_on_exception(self, monkeypatch):
+        def _raise(name):
+            raise OSError("boom")
+
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", _raise)
+        assert check_binary("tesseract") is None
+
+
+# ---------------------------------------------------------------------------
+# check_python_package
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPythonPackage:
+    def test_returns_true_for_available_package(self):
+        # 'os' is always available
+        assert check_python_package("os") is True
+
+    def test_returns_false_for_missing_package(self):
+        assert check_python_package("nonexistent_pkg_xyz_999") is False
+
+
+# ---------------------------------------------------------------------------
+# check_all_capabilities – all binaries missing, all packages missing
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAllCapabilitiesAllMissing:
+    def test_all_binaries_missing(self, monkeypatch):
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", lambda name: None)
+        # Make all Python packages appear missing
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.check_python_package", lambda name: False
+        )
+
+        caps = check_all_capabilities()
+
+        for name in CAPABILITY_REGISTRY:
+            assert caps[name]["available"] is False
+            assert caps[name]["path"] is None
+            assert "install_hint" in caps[name]
+
+        for name in PYTHON_PACKAGE_REGISTRY:
+            assert caps[name]["available"] is False
+            assert "install_hint" in caps[name]
+
+    def test_all_binaries_present(self, monkeypatch):
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.shutil.which",
+            lambda name: f"/usr/bin/{name}",
+        )
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck._get_version", lambda path: "1.0.0"
+        )
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.check_python_package", lambda name: True
+        )
+
+        caps = check_all_capabilities()
+
+        for name in CAPABILITY_REGISTRY:
+            assert caps[name]["available"] is True
+            assert caps[name]["path"] is not None
+
+        for name in PYTHON_PACKAGE_REGISTRY:
+            assert caps[name]["available"] is True
+
+
+# ---------------------------------------------------------------------------
+# check_all_capabilities – fallback binary
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAllCapabilitiesFallback:
+    def test_imagemagick_uses_fallback(self, monkeypatch):
+        """When 'magick' is missing but 'convert' is found, use the fallback."""
+
+        def _which(name):
+            if name == "convert":
+                return "/usr/bin/convert"
+            return None
+
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", _which)
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck._get_version", lambda path: None
+        )
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.check_python_package", lambda name: False
+        )
+
+        caps = check_all_capabilities()
+
+        assert caps["imagemagick"]["available"] is True
+        assert caps["imagemagick"]["path"] == "/usr/bin/convert"
+        assert "fallback" in caps["imagemagick"].get("note", "").lower()
+
+    def test_ghostscript_uses_fallback(self, monkeypatch):
+        """When 'gs' is missing but 'gswin64c' is found, use the fallback."""
+
+        def _which(name):
+            if name == "gswin64c":
+                return "C:\\Program Files\\gs\\bin\\gswin64c.exe"
+            return None
+
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", _which)
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck._get_version", lambda path: None
+        )
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.check_python_package", lambda name: False
+        )
+
+        caps = check_all_capabilities()
+
+        assert caps["ghostscript"]["available"] is True
+        assert "gswin64c" in caps["ghostscript"]["path"]
+
+
+# ---------------------------------------------------------------------------
+# format_capability_report
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCapabilityReport:
+    def test_report_contains_header(self):
+        caps = {
+            "tesseract": {
+                "available": True,
+                "feature": "OCR text extraction",
+                "path": "/usr/bin/tesseract",
+                "version": "5.3.0",
+            },
+        }
+        report = format_capability_report(caps)
+        assert "DocTest Environment Capability Report" in report
+        assert "tesseract" in report
+        assert "OK" in report
+
+    def test_report_shows_missing_with_hint(self):
+        caps = {
+            "ghostpcl": {
+                "available": False,
+                "feature": "PCL document rendering",
+                "path": None,
+                "install_hint": "Install GhostPCL",
+            },
+        }
+        report = format_capability_report(caps)
+        assert "MISSING" in report
+        assert "Install GhostPCL" in report
+
+    def test_report_summary_line(self):
+        caps = {
+            "a": {"available": True, "feature": "A"},
+            "b": {"available": False, "feature": "B"},
+            "c": {"available": True, "feature": "C"},
+        }
+        report = format_capability_report(caps)
+        assert "2/3 capabilities available" in report
+
+    def test_report_shows_version_and_note(self):
+        caps = {
+            "imagemagick": {
+                "available": True,
+                "feature": "Image format conversion",
+                "path": "/usr/bin/convert",
+                "version": "7.1.0",
+                "note": "Using fallback 'convert' command",
+            },
+        }
+        report = format_capability_report(caps)
+        assert "7.1.0" in report
+        assert "fallback" in report
+
+
+# ---------------------------------------------------------------------------
+# CapabilityCheck Robot keyword
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityCheckKeyword:
+    def test_keyword_returns_dict(self, monkeypatch):
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", lambda name: None)
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.check_python_package", lambda name: False
+        )
+
+        lib = CapabilityCheck()
+        result = lib.check_doctest_environment()
+
+        assert isinstance(result, dict)
+        # Must contain all registered capabilities
+        for name in CAPABILITY_REGISTRY:
+            assert name in result
+        for name in PYTHON_PACKAGE_REGISTRY:
+            assert name in result
+
+    def test_keyword_logs_report(self, monkeypatch, caplog):
+        monkeypatch.setattr("DocTest.CapabilityCheck.shutil.which", lambda name: None)
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.check_python_package", lambda name: False
+        )
+
+        lib = CapabilityCheck()
+        with caplog.at_level("INFO", logger="DocTest.CapabilityCheck"):
+            lib.check_doctest_environment()
+
+        assert "DocTest Environment Capability Report" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _get_version
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersion:
+    def test_returns_version_string(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from DocTest.CapabilityCheck import _get_version
+
+        mock_result = MagicMock()
+        mock_result.stdout = "tesseract 5.3.0\nlinesep info"
+        mock_result.stderr = ""
+
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.subprocess.run",
+            lambda *args, **kwargs: mock_result,
+        )
+        version = _get_version("/usr/bin/tesseract")
+        assert version == "tesseract 5.3.0"
+
+    def test_returns_none_on_failure(self, monkeypatch):
+        from DocTest.CapabilityCheck import _get_version
+
+        def _raise(*args, **kwargs):
+            raise FileNotFoundError("not found")
+
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.subprocess.run", _raise
+        )
+        version = _get_version("/nonexistent/binary")
+        assert version is None
+
+    def test_falls_back_to_stderr(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from DocTest.CapabilityCheck import _get_version
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = "gs 10.0.0"
+
+        monkeypatch.setattr(
+            "DocTest.CapabilityCheck.subprocess.run",
+            lambda *args, **kwargs: mock_result,
+        )
+        version = _get_version("/usr/bin/gs")
+        assert version == "gs 10.0.0"

--- a/utest/test_downloader_extended.py
+++ b/utest/test_downloader_extended.py
@@ -1,9 +1,20 @@
 """Unit tests for Downloader module."""
 
 import os
+import logging
 from unittest.mock import patch
 
-from DocTest.Downloader import download_file_from_url, get_filename_from_url, is_url
+import pytest
+
+from DocTest.Downloader import (
+    ALLOWED_SCHEMES,
+    DEFAULT_MAX_SIZE,
+    _warn_if_html_content,
+    convert_github_blob_to_raw,
+    download_file_from_url,
+    get_filename_from_url,
+    is_url,
+)
 
 
 class TestIsUrl:
@@ -57,11 +68,14 @@ class TestIsUrl:
 class TestDownloadFileFromUrl:
     """Test cases for download_file_from_url function."""
 
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
     @patch("DocTest.Downloader.urllib.request.urlretrieve")
     @patch("DocTest.Downloader.tempfile.gettempdir")
     @patch("DocTest.Downloader.uuid.uuid4")
     def test_download_with_default_params(
-        self, mock_uuid, mock_gettempdir, mock_urlretrieve
+        self, mock_uuid, mock_gettempdir, mock_urlretrieve, mock_getsize,
+        mock_warn_html
     ):
         """Test download with default directory and filename."""
         mock_gettempdir.return_value = "/tmp"
@@ -74,9 +88,13 @@ class TestDownloadFileFromUrl:
         assert result == expected_path
         mock_urlretrieve.assert_called_once_with(url, expected_path)
 
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
     @patch("DocTest.Downloader.urllib.request.urlretrieve")
     @patch("DocTest.Downloader.uuid.uuid4")
-    def test_download_with_custom_directory(self, mock_uuid, mock_urlretrieve):
+    def test_download_with_custom_directory(
+        self, mock_uuid, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
         """Test download with custom directory."""
         mock_uuid.return_value = "test-uuid"
         url = "https://example.com/test.pdf"
@@ -88,8 +106,12 @@ class TestDownloadFileFromUrl:
         assert result == expected_path
         mock_urlretrieve.assert_called_once_with(url, expected_path)
 
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
     @patch("DocTest.Downloader.urllib.request.urlretrieve")
-    def test_download_with_custom_filename(self, mock_urlretrieve):
+    def test_download_with_custom_filename(
+        self, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
         """Test download with custom filename."""
         url = "https://example.com/test.pdf"
         directory = "/custom/dir"
@@ -101,38 +123,91 @@ class TestDownloadFileFromUrl:
         assert result == expected_path
         mock_urlretrieve.assert_called_once_with(url, expected_path)
 
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
     @patch("DocTest.Downloader.urllib.request.urlretrieve")
     @patch("DocTest.Downloader.tempfile.gettempdir")
     @patch("DocTest.Downloader.uuid.uuid4")
     def test_download_url_without_extension(
-        self, mock_uuid, mock_gettempdir, mock_urlretrieve
+        self, mock_uuid, mock_gettempdir, mock_urlretrieve, mock_getsize,
+        mock_warn_html
     ):
-        """Test download with URL without file extension."""
+        """Test download with URL without file extension.
+
+        When the URL path has no extension, the filename should be a UUID
+        with no extension (not a broken path fragment like 'com/path/file').
+        """
         mock_gettempdir.return_value = "/tmp"
         mock_uuid.return_value = "test-uuid"
         url = "https://example.com/path/file"
 
         result = download_file_from_url(url)
 
-        # The implementation splits by '.' and takes the last part as extension
-        # For "https://example.com/path/file", the last part after splitting by '.' is "com/path/file"
-        expected_path = os.path.join("/tmp", "test-uuid.com/path/file")
+        expected_path = os.path.join("/tmp", "test-uuid")
         assert result == expected_path
 
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
     @patch("DocTest.Downloader.urllib.request.urlretrieve")
     @patch("DocTest.Downloader.uuid.uuid4")
-    def test_download_url_with_query_params(self, mock_uuid, mock_urlretrieve):
-        """Test download with URL containing query parameters."""
+    def test_download_url_with_query_params(
+        self, mock_uuid, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test download with URL containing query parameters.
+
+        Query parameters should be stripped; only the clean extension
+        should be used in the filename.
+        """
         mock_uuid.return_value = "test-uuid"
         url = "https://example.com/test.pdf?param=value"
         directory = "/test/dir"
 
         result = download_file_from_url(url, directory=directory)
 
-        # The implementation splits by '.' and takes the last part as extension
-        # For the URL with query params, it would be "pdf?param=value"
-        expected_path = os.path.join(directory, "test-uuid.pdf?param=value")
+        expected_path = os.path.join(directory, "test-uuid.pdf")
         assert result == expected_path
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    @patch("DocTest.Downloader.uuid.uuid4")
+    def test_download_url_with_fragment(
+        self, mock_uuid, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test download with URL containing fragment identifier.
+
+        Fragments should be stripped; only the clean extension
+        should be used in the filename.
+        """
+        mock_uuid.return_value = "test-uuid"
+        url = "https://example.com/test.pdf#page=5"
+        directory = "/test/dir"
+
+        result = download_file_from_url(url, directory=directory)
+
+        expected_path = os.path.join(directory, "test-uuid.pdf")
+        assert result == expected_path
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    @patch("DocTest.Downloader.uuid.uuid4")
+    def test_download_github_blob_url_converts_to_raw(
+        self, mock_uuid, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test that GitHub blob URLs are converted to raw URLs for download."""
+        mock_uuid.return_value = "test-uuid"
+        url = "https://github.com/user/repo/blob/main/path/file.png"
+        directory = "/test/dir"
+
+        result = download_file_from_url(url, directory=directory)
+
+        expected_path = os.path.join(directory, "test-uuid.png")
+        assert result == expected_path
+        expected_raw_url = (
+            "https://raw.githubusercontent.com/user/repo/main/path/file.png"
+        )
+        mock_urlretrieve.assert_called_once_with(expected_raw_url, expected_path)
 
 
 class TestGetFilenameFromUrl:
@@ -163,24 +238,32 @@ class TestGetFilenameFromUrl:
         assert result is None
 
     def test_url_root_domain(self):
-        """Test URL with root domain only."""
+        """Test URL with root domain only.
+
+        When the URL has no path component, the basename of the path is empty,
+        so the function should return None (not the domain like 'example.com').
+        """
         url = "https://example.com"
         result = get_filename_from_url(url)
-        # The function splits by '/' and takes the last part, which would be "example.com"
-        # Since it contains a dot, it's considered a valid filename
-        assert result == "example.com"
+        assert result is None
 
     def test_url_with_query_params(self):
-        """Test URL with query parameters."""
+        """Test URL with query parameters.
+
+        Query parameters should be stripped from the filename.
+        """
         url = "https://example.com/document.pdf?download=true"
         result = get_filename_from_url(url)
-        assert result == "document.pdf?download=true"
+        assert result == "document.pdf"
 
     def test_url_with_fragment(self):
-        """Test URL with fragment identifier."""
+        """Test URL with fragment identifier.
+
+        Fragments should be stripped from the filename.
+        """
         url = "https://example.com/document.pdf#page=1"
         result = get_filename_from_url(url)
-        assert result == "document.pdf#page=1"
+        assert result == "document.pdf"
 
     def test_none_url(self):
         """Test with None URL."""
@@ -203,3 +286,308 @@ class TestGetFilenameFromUrl:
         url = "https://example.com/my%20document.pdf"
         result = get_filename_from_url(url)
         assert result == "my%20document.pdf"
+
+
+class TestConvertGithubBlobToRaw:
+    """Test cases for convert_github_blob_to_raw function."""
+
+    def test_github_blob_url(self):
+        """Test conversion of a standard GitHub blob URL."""
+        url = "https://github.com/user/repo/blob/main/path/to/file.py"
+        result = convert_github_blob_to_raw(url)
+        assert result == (
+            "https://raw.githubusercontent.com/user/repo/main/path/to/file.py"
+        )
+
+    def test_github_blob_url_with_branch(self):
+        """Test conversion with a specific branch name."""
+        url = "https://github.com/user/repo/blob/feature-branch/src/app.js"
+        result = convert_github_blob_to_raw(url)
+        assert result == (
+            "https://raw.githubusercontent.com/user/repo/feature-branch/src/app.js"
+        )
+
+    def test_github_blob_url_with_commit_sha(self):
+        """Test conversion with a commit SHA."""
+        url = "https://github.com/user/repo/blob/abc123def/README.md"
+        result = convert_github_blob_to_raw(url)
+        assert result == (
+            "https://raw.githubusercontent.com/user/repo/abc123def/README.md"
+        )
+
+    def test_non_github_url_unchanged(self):
+        """Test that non-GitHub URLs are returned unchanged."""
+        url = "https://example.com/path/to/file.pdf"
+        result = convert_github_blob_to_raw(url)
+        assert result == url
+
+    def test_github_non_blob_url_unchanged(self):
+        """Test that GitHub URLs without /blob/ are returned unchanged."""
+        url = "https://github.com/user/repo/tree/main/src"
+        result = convert_github_blob_to_raw(url)
+        assert result == url
+
+    def test_github_raw_url_unchanged(self):
+        """Test that already-raw GitHub URLs are returned unchanged."""
+        url = "https://raw.githubusercontent.com/user/repo/main/file.py"
+        result = convert_github_blob_to_raw(url)
+        assert result == url
+
+    def test_github_blob_url_http(self):
+        """Test conversion of HTTP (not HTTPS) GitHub blob URL."""
+        url = "http://github.com/user/repo/blob/main/file.txt"
+        result = convert_github_blob_to_raw(url)
+        assert result == (
+            "https://raw.githubusercontent.com/user/repo/main/file.txt"
+        )
+
+
+class TestSchemeValidation:
+    """Test cases for URL scheme validation in download_file_from_url."""
+
+    def test_file_scheme_rejected(self):
+        """Test that file:// URLs are rejected."""
+        with pytest.raises(ValueError, match="scheme 'file' is not allowed"):
+            download_file_from_url("file:///etc/passwd")
+
+    def test_data_scheme_rejected(self):
+        """Test that data: URLs are rejected."""
+        with pytest.raises(ValueError, match="scheme 'data' is not allowed"):
+            download_file_from_url("data:text/html,<h1>hello</h1>")
+
+    def test_javascript_scheme_rejected(self):
+        """Test that javascript: URLs are rejected."""
+        with pytest.raises(ValueError, match="scheme 'javascript' is not allowed"):
+            download_file_from_url("javascript:alert(1)")
+
+    def test_empty_scheme_rejected(self):
+        """Test that URLs with no scheme are rejected."""
+        with pytest.raises(ValueError, match="scheme '' is not allowed"):
+            download_file_from_url("//example.com/test.pdf")
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    def test_http_scheme_allowed(
+        self, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test that http:// URLs are allowed."""
+        result = download_file_from_url(
+            "http://example.com/test.pdf",
+            directory="/tmp",
+            filename="test.pdf",
+        )
+        assert result == os.path.join("/tmp", "test.pdf")
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    def test_https_scheme_allowed(
+        self, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test that https:// URLs are allowed."""
+        result = download_file_from_url(
+            "https://example.com/test.pdf",
+            directory="/tmp",
+            filename="test.pdf",
+        )
+        assert result == os.path.join("/tmp", "test.pdf")
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize", return_value=1024)
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    def test_ftp_scheme_allowed(
+        self, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test that ftp:// URLs are allowed."""
+        result = download_file_from_url(
+            "ftp://ftp.example.com/test.zip",
+            directory="/tmp",
+            filename="test.zip",
+        )
+        assert result == os.path.join("/tmp", "test.zip")
+
+
+class TestIsUrlWithAllowedSchemes:
+    """Test cases for is_url with the allowed_schemes parameter."""
+
+    def test_default_no_scheme_filter(self):
+        """Test backward compatibility: without allowed_schemes, any scheme works."""
+        assert is_url("ftp://ftp.example.com") is True
+        assert is_url("http://example.com") is True
+        assert is_url("https://example.com") is True
+        assert is_url("custom://some.host") is True
+
+    def test_allowed_schemes_filter(self):
+        """Test that allowed_schemes restricts accepted schemes."""
+        assert is_url("https://example.com", allowed_schemes=("https",)) is True
+        assert is_url("http://example.com", allowed_schemes=("https",)) is False
+        assert is_url("ftp://ftp.example.com", allowed_schemes=("https",)) is False
+
+    def test_allowed_schemes_multiple(self):
+        """Test with multiple allowed schemes."""
+        schemes = ("http", "https")
+        assert is_url("http://example.com", allowed_schemes=schemes) is True
+        assert is_url("https://example.com", allowed_schemes=schemes) is True
+        assert is_url("ftp://ftp.example.com", allowed_schemes=schemes) is False
+
+    def test_allowed_schemes_with_module_constant(self):
+        """Test with the module-level ALLOWED_SCHEMES constant."""
+        assert is_url("http://example.com", allowed_schemes=ALLOWED_SCHEMES) is True
+        assert is_url("https://example.com", allowed_schemes=ALLOWED_SCHEMES) is True
+        assert is_url("ftp://ftp.example.com", allowed_schemes=ALLOWED_SCHEMES) is True
+        assert is_url("custom://some.host", allowed_schemes=ALLOWED_SCHEMES) is False
+
+    def test_invalid_url_still_rejected_with_schemes(self):
+        """Test that invalid URLs are still rejected even with allowed_schemes."""
+        assert is_url("not-a-url", allowed_schemes=ALLOWED_SCHEMES) is False
+        assert is_url("", allowed_schemes=ALLOWED_SCHEMES) is False
+        assert is_url(None, allowed_schemes=ALLOWED_SCHEMES) is False
+
+
+class TestFileSizeValidation:
+    """Test cases for file size validation in download_file_from_url."""
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.remove")
+    @patch("DocTest.Downloader.os.path.getsize")
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    def test_oversized_file_rejected(
+        self, mock_urlretrieve, mock_getsize, mock_remove, mock_warn_html
+    ):
+        """Test that files exceeding max_size are rejected and deleted."""
+        mock_getsize.return_value = 200 * 1024 * 1024  # 200 MB
+        url = "https://example.com/large_file.bin"
+
+        with pytest.raises(ValueError, match="exceeds maximum allowed size"):
+            download_file_from_url(url, directory="/tmp", filename="large.bin")
+
+        # The file should have been deleted
+        mock_remove.assert_called_once_with(os.path.join("/tmp", "large.bin"))
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize")
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    def test_file_within_default_max_size_accepted(
+        self, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test that files within DEFAULT_MAX_SIZE are accepted."""
+        mock_getsize.return_value = 50 * 1024 * 1024  # 50 MB
+        url = "https://example.com/file.pdf"
+
+        result = download_file_from_url(url, directory="/tmp", filename="file.pdf")
+        assert result == os.path.join("/tmp", "file.pdf")
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.remove")
+    @patch("DocTest.Downloader.os.path.getsize")
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    def test_custom_max_size(
+        self, mock_urlretrieve, mock_getsize, mock_remove, mock_warn_html
+    ):
+        """Test that a custom max_size is respected."""
+        mock_getsize.return_value = 2048  # 2 KB
+        url = "https://example.com/file.pdf"
+
+        with pytest.raises(ValueError, match="exceeds maximum allowed size"):
+            download_file_from_url(
+                url, directory="/tmp", filename="file.pdf", max_size=1024
+            )
+
+    @patch("DocTest.Downloader._warn_if_html_content")
+    @patch("DocTest.Downloader.os.path.getsize")
+    @patch("DocTest.Downloader.urllib.request.urlretrieve")
+    def test_file_at_exact_max_size_accepted(
+        self, mock_urlretrieve, mock_getsize, mock_warn_html
+    ):
+        """Test that a file exactly at max_size is accepted (not exceeded)."""
+        mock_getsize.return_value = 1024
+        url = "https://example.com/file.pdf"
+
+        result = download_file_from_url(
+            url, directory="/tmp", filename="file.pdf", max_size=1024
+        )
+        assert result == os.path.join("/tmp", "file.pdf")
+
+    def test_default_max_size_constant(self):
+        """Test that DEFAULT_MAX_SIZE is 100 MB."""
+        assert DEFAULT_MAX_SIZE == 100 * 1024 * 1024
+
+
+class TestHtmlContentDetection:
+    """Test cases for HTML content detection warning."""
+
+    def test_html_doctype_detected(self, tmp_path):
+        """Test that <!DOCTYPE html> content triggers a warning."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"<!DOCTYPE html><html><body>Error</body></html>")
+
+        with patch("DocTest.Downloader.logger") as mock_logger:
+            _warn_if_html_content(str(test_file), "https://example.com/test.pdf")
+            mock_logger.warning.assert_called_once()
+            assert "appears to contain HTML" in mock_logger.warning.call_args[0][0]
+
+    def test_html_tag_detected(self, tmp_path):
+        """Test that <html> content triggers a warning."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"<html><head><title>Login</title></head></html>")
+
+        with patch("DocTest.Downloader.logger") as mock_logger:
+            _warn_if_html_content(str(test_file), "https://example.com/test.pdf")
+            mock_logger.warning.assert_called_once()
+
+    def test_html_with_leading_whitespace_detected(self, tmp_path):
+        """Test that HTML content with leading whitespace is still detected."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"  \n  <!DOCTYPE html><html><body></body></html>")
+
+        with patch("DocTest.Downloader.logger") as mock_logger:
+            _warn_if_html_content(str(test_file), "https://example.com/test.pdf")
+            mock_logger.warning.assert_called_once()
+
+    def test_non_html_content_no_warning(self, tmp_path):
+        """Test that binary/non-HTML content does not trigger a warning."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"%PDF-1.4 some pdf content here")
+
+        with patch("DocTest.Downloader.logger") as mock_logger:
+            _warn_if_html_content(str(test_file), "https://example.com/test.pdf")
+            mock_logger.warning.assert_not_called()
+
+    def test_html_extension_no_warning(self, tmp_path):
+        """Test that .html files do not trigger a warning even with HTML content."""
+        test_file = tmp_path / "page.html"
+        test_file.write_bytes(b"<!DOCTYPE html><html><body>OK</body></html>")
+
+        with patch("DocTest.Downloader.logger") as mock_logger:
+            _warn_if_html_content(str(test_file), "https://example.com/page.html")
+            mock_logger.warning.assert_not_called()
+
+    def test_htm_extension_no_warning(self, tmp_path):
+        """Test that .htm files do not trigger a warning even with HTML content."""
+        test_file = tmp_path / "page.htm"
+        test_file.write_bytes(b"<html><body>OK</body></html>")
+
+        with patch("DocTest.Downloader.logger") as mock_logger:
+            _warn_if_html_content(str(test_file), "https://example.com/page.htm")
+            mock_logger.warning.assert_not_called()
+
+    def test_nonexistent_file_no_error(self):
+        """Test that a nonexistent file does not raise an error."""
+        _warn_if_html_content("/nonexistent/path/file.pdf", "https://example.com/file.pdf")
+
+
+class TestModuleConstants:
+    """Test cases for module-level constants."""
+
+    def test_allowed_schemes(self):
+        """Test that ALLOWED_SCHEMES contains expected values."""
+        assert "http" in ALLOWED_SCHEMES
+        assert "https" in ALLOWED_SCHEMES
+        assert "ftp" in ALLOWED_SCHEMES
+        assert "file" not in ALLOWED_SCHEMES
+        assert "data" not in ALLOWED_SCHEMES
+
+    def test_default_max_size_is_100mb(self):
+        """Test that DEFAULT_MAX_SIZE is 100 MB."""
+        assert DEFAULT_MAX_SIZE == 104857600  # 100 * 1024 * 1024

--- a/utest/test_ignore_area_manager.py
+++ b/utest/test_ignore_area_manager.py
@@ -1,6 +1,9 @@
 """Unit tests for IgnoreAreaManager module."""
 
+import logging
 from unittest.mock import mock_open, patch
+
+import numpy as np
 
 from DocTest.IgnoreAreaManager import IgnoreAreaManager
 
@@ -47,19 +50,18 @@ class TestIgnoreAreaManager:
         mock_file.assert_called_once_with("test.json", "r")
 
     @patch("builtins.open", side_effect=IOError("File not found"))
-    @patch("builtins.print")
-    def test_load_ignore_area_file_io_error(self, mock_print, mock_file):
+    def test_load_ignore_area_file_io_error(self, mock_file, caplog):
         """Test loading ignore area file with IO error."""
         manager = IgnoreAreaManager(ignore_area_file="nonexistent.json")
-        result = manager._load_ignore_area_file()
+        with caplog.at_level(logging.ERROR, logger="DocTest.IgnoreAreaManager"):
+            result = manager._load_ignore_area_file()
 
         assert result is None
-        assert mock_print.call_count >= 2  # Two print statements
+        assert len(caplog.records) >= 2  # Two log messages
 
     @patch("builtins.open", new_callable=mock_open, read_data="invalid json")
-    @patch("builtins.print")
-    def test_load_ignore_area_file_json_error(self, mock_print, mock_file):
-        """Test loading ignore area file with invalid JSON."""
+    def test_load_ignore_area_file_json_error(self, mock_file):
+        """Test loading ignore area file with invalid JSON raises exception."""
         manager = IgnoreAreaManager(ignore_area_file="invalid.json")
 
         try:
@@ -114,25 +116,27 @@ class TestIgnoreAreaManager:
         ]
         assert result == expected
 
-    @patch("builtins.print")
-    def test_parse_mask_string_invalid_location(self, mock_print):
+    def test_parse_mask_string_invalid_location(self, caplog):
         """Test parsing mask string with invalid location."""
         mask = "invalid:10"
         manager = IgnoreAreaManager(mask=mask)
-        result = manager._parse_mask()
+        with caplog.at_level(logging.WARNING, logger="DocTest.IgnoreAreaManager"):
+            result = manager._parse_mask()
 
         assert result == []
-        mock_print.assert_called()
+        assert len(caplog.records) == 1
+        assert "invalid location" in caplog.records[0].message
 
-    @patch("builtins.print")
-    def test_parse_mask_string_invalid_percent(self, mock_print):
+    def test_parse_mask_string_invalid_percent(self, caplog):
         """Test parsing mask string with invalid percent."""
         mask = "top:invalid"
         manager = IgnoreAreaManager(mask=mask)
-        result = manager._parse_mask()
+        with caplog.at_level(logging.WARNING, logger="DocTest.IgnoreAreaManager"):
+            result = manager._parse_mask()
 
         assert result == []
-        mock_print.assert_called()
+        assert len(caplog.records) == 1
+        assert "not a number" in caplog.records[0].message
 
     def test_parse_mask_string_empty(self):
         """Test parsing empty mask string."""
@@ -191,39 +195,228 @@ class TestIgnoreAreaManager:
 
         assert result == [{"page": 1, "type": "area"}]
 
-    def test_convert_to_pixels_px_unit(self):
-        """Test converting coordinates to pixels with px unit."""
-        manager = IgnoreAreaManager()
-        ignore_area = {"x": 10, "y": 20, "height": 30, "width": 40}
-        x, y, h, w = manager._convert_to_pixels(ignore_area, "px", 200)
+    def test_parse_mask_string_missing_colon(self, caplog):
+        """Test parsing mask string without colon separator."""
+        mask = "top10"
+        manager = IgnoreAreaManager(mask=mask)
+        with caplog.at_level(logging.WARNING, logger="DocTest.IgnoreAreaManager"):
+            result = manager._parse_mask()
 
-        assert x == 10
-        assert y == 20
-        assert h == 30
-        assert w == 40
+        assert result == []
+        assert len(caplog.records) == 1
+        assert "Expected format" in caplog.records[0].message
 
-    def test_convert_to_pixels_mm_unit(self):
-        """Test converting coordinates to pixels with mm unit."""
-        manager = IgnoreAreaManager()
-        ignore_area = {"x": 10, "y": 20, "height": 30, "width": 40}
-        x, y, h, w = manager._convert_to_pixels(
-            ignore_area, "mm", 254
-        )  # 254 DPI = 10 px/mm
 
-        assert x == 100  # 10 * (254/25.4) = 100
-        assert y == 200  # 20 * (254/25.4) = 200
-        assert h == 300  # 30 * (254/25.4) = 300
-        assert w == 400  # 40 * (254/25.4) = 400
+class TestAreaMaskExecution:
+    """Test area mask execution through the Page class (the real runtime path).
 
-    def test_convert_to_pixels_cm_unit(self):
-        """Test converting coordinates to pixels with cm unit."""
-        manager = IgnoreAreaManager()
-        ignore_area = {"x": 1, "y": 2, "height": 3, "width": 4}
-        x, y, h, w = manager._convert_to_pixels(
-            ignore_area, "cm", 254
-        )  # 254 DPI = 100 px/cm
+    IgnoreAreaManager parses mask strings into abstract ignore areas.
+    Page._process_area_ignore_area converts those into pixel-based ignore areas
+    using the actual image dimensions.
+    """
 
-        assert x == 100  # 1 * (254/2.54) = 100
-        assert y == 200  # 2 * (254/2.54) = 200
-        assert h == 300  # 3 * (254/2.54) = 300
-        assert w == 400  # 4 * (254/2.54) = 400
+    def _make_page(self, height=1000, width=800, page_number=1, dpi=200):
+        """Create a minimal Page object with a fake image for testing."""
+        from DocTest.DocumentRepresentation import Page
+
+        image = np.zeros((height, width, 3), dtype=np.uint8)
+        page = Page(image=image, page_number=page_number, dpi=dpi)
+        return page
+
+    def test_area_top(self):
+        """Test area mask for 'top' location."""
+        page = self._make_page(height=1000, width=800)
+        ignore_area = {"page": "all", "type": "area", "location": "top", "percent": "10"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 1
+        area = page.pixel_ignore_areas[0]
+        assert area["x"] == 0
+        assert area["y"] == 0
+        assert area["width"] == 800
+        assert area["height"] == 100  # 10% of 1000
+
+    def test_area_bottom(self):
+        """Test area mask for 'bottom' location."""
+        page = self._make_page(height=1000, width=800)
+        ignore_area = {"page": "all", "type": "area", "location": "bottom", "percent": "20"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 1
+        area = page.pixel_ignore_areas[0]
+        assert area["x"] == 0
+        assert area["y"] == 800  # 1000 - 200
+        assert area["width"] == 800
+        assert area["height"] == 200  # 20% of 1000
+
+    def test_area_left(self):
+        """Test area mask for 'left' location."""
+        page = self._make_page(height=1000, width=800)
+        ignore_area = {"page": "all", "type": "area", "location": "left", "percent": "25"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 1
+        area = page.pixel_ignore_areas[0]
+        assert area["x"] == 0
+        assert area["y"] == 0
+        assert area["width"] == 200  # 25% of 800
+        assert area["height"] == 1000
+
+    def test_area_right(self):
+        """Test area mask for 'right' location."""
+        page = self._make_page(height=1000, width=800)
+        ignore_area = {"page": "all", "type": "area", "location": "right", "percent": "15"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 1
+        area = page.pixel_ignore_areas[0]
+        assert area["x"] == 680  # 800 - 120
+        assert area["y"] == 0
+        assert area["width"] == 120  # 15% of 800
+        assert area["height"] == 1000
+
+    def test_page_filter_all(self):
+        """Test that page='all' applies ignore area to any page."""
+        for page_num in [1, 2, 5]:
+            page = self._make_page(height=1000, width=800, page_number=page_num)
+            ignore_area = {"page": "all", "type": "area", "location": "top", "percent": "10"}
+
+            page._process_area_ignore_area(ignore_area)
+
+            assert len(page.pixel_ignore_areas) == 1, (
+                f"page='all' should apply to page {page_num}"
+            )
+
+    def test_page_filter_specific_match(self):
+        """Test that a specific page number matches the correct page."""
+        page = self._make_page(height=1000, width=800, page_number=3)
+        ignore_area = {"page": 3, "type": "area", "location": "top", "percent": "10"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 1
+
+    def test_page_filter_specific_no_match(self):
+        """Test that a specific page number does not match a different page."""
+        page = self._make_page(height=1000, width=800, page_number=1)
+        ignore_area = {"page": 3, "type": "area", "location": "top", "percent": "10"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 0
+
+    def test_page_filter_string_page_number(self):
+        """Test that page number given as string is cast to int for comparison."""
+        page = self._make_page(height=1000, width=800, page_number=2)
+        ignore_area = {"page": "2", "type": "area", "location": "top", "percent": "10"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 1
+
+    def test_invalid_location_still_appends(self):
+        """Test that an unrecognized location still appends the full image area.
+
+        The Page implementation defaults to full image dimensions when
+        no location branch matches. This documents the current behavior.
+        """
+        page = self._make_page(height=1000, width=800)
+        ignore_area = {"page": "all", "type": "area", "location": "center", "percent": "10"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        # Current behavior: appends the full image as ignore area
+        assert len(page.pixel_ignore_areas) == 1
+        area = page.pixel_ignore_areas[0]
+        assert area["x"] == 0
+        assert area["y"] == 0
+        assert area["width"] == 800
+        assert area["height"] == 1000
+
+    def test_missing_location_defaults_to_none(self):
+        """Test that a missing location key defaults to None and uses full image."""
+        page = self._make_page(height=1000, width=800)
+        ignore_area = {"page": "all", "type": "area", "percent": "10"}
+
+        page._process_area_ignore_area(ignore_area)
+
+        assert len(page.pixel_ignore_areas) == 1
+        area = page.pixel_ignore_areas[0]
+        assert area["width"] == 800
+        assert area["height"] == 1000
+
+    def test_end_to_end_parse_and_process(self):
+        """Test the full pipeline: IgnoreAreaManager parses, Page processes."""
+        manager = IgnoreAreaManager(mask="top:10;bottom:20;left:5")
+        areas = manager.read_ignore_areas()
+
+        assert len(areas) == 3
+
+        page = self._make_page(height=2000, width=1000, page_number=1)
+        for area in areas:
+            page._process_area_ignore_area(area)
+
+        assert len(page.pixel_ignore_areas) == 3
+
+        # top:10 => top 10% of 2000px height = 200px
+        top_area = page.pixel_ignore_areas[0]
+        assert top_area["x"] == 0
+        assert top_area["y"] == 0
+        assert top_area["height"] == 200
+        assert top_area["width"] == 1000
+
+        # bottom:20 => bottom 20% of 2000px height = 400px
+        bottom_area = page.pixel_ignore_areas[1]
+        assert bottom_area["x"] == 0
+        assert bottom_area["y"] == 1600  # 2000 - 400
+        assert bottom_area["height"] == 400
+        assert bottom_area["width"] == 1000
+
+        # left:5 => left 5% of 1000px width = 50px
+        left_area = page.pixel_ignore_areas[2]
+        assert left_area["x"] == 0
+        assert left_area["y"] == 0
+        assert left_area["width"] == 50
+        assert left_area["height"] == 2000
+
+    def test_end_to_end_json_mask_with_coordinates(self):
+        """Test end-to-end with a JSON coordinate mask."""
+        mask = '[{"page": "all", "type": "coordinates", "x": 10, "y": 20, "width": 100, "height": 50}]'
+        manager = IgnoreAreaManager(mask=mask)
+        areas = manager.read_ignore_areas()
+
+        assert len(areas) == 1
+
+        page = self._make_page(height=1000, width=800, page_number=1)
+        page._process_coordinates_ignore_area(areas[0])
+
+        assert len(page.pixel_ignore_areas) == 1
+        area = page.pixel_ignore_areas[0]
+        assert area["x"] == 10
+        assert area["y"] == 20
+        assert area["width"] == 100
+        assert area["height"] == 50
+
+    def test_multiple_pages_selective_application(self):
+        """Test that page-specific ignore areas apply only to matching pages."""
+        areas = [
+            {"page": 1, "type": "area", "location": "top", "percent": "10"},
+            {"page": 2, "type": "area", "location": "bottom", "percent": "20"},
+            {"page": "all", "type": "area", "location": "left", "percent": "5"},
+        ]
+
+        page1 = self._make_page(height=1000, width=800, page_number=1)
+        page2 = self._make_page(height=1000, width=800, page_number=2)
+
+        for area in areas:
+            page1._process_area_ignore_area(area)
+            page2._process_area_ignore_area(area)
+
+        # Page 1 gets: top (page=1 match) + left (page=all)
+        assert len(page1.pixel_ignore_areas) == 2
+        # Page 2 gets: bottom (page=2 match) + left (page=all)
+        assert len(page2.pixel_ignore_areas) == 2

--- a/utest/test_llm_branches.py
+++ b/utest/test_llm_branches.py
@@ -1,0 +1,718 @@
+"""Tests for all LLM decision branches in visual and PDF comparison flows.
+
+Every test uses mocks -- no real LLM API calls are made.
+"""
+
+import datetime
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pydantic", reason="LLM branch tests require optional dependencies.")
+
+from DocTest.VisualTest import VisualTest
+from DocTest.PdfTest import PdfTest
+from DocTest.llm.config import LLMSettings
+from DocTest.llm.types import LLMDecision, LLMDecisionLabel
+from DocTest.llm.exceptions import LLMDependencyError
+import DocTest.VisualTest as visual_module
+import DocTest.PdfTest as pdf_module
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dummy_settings(*, visual=False, pdf=False):
+    return LLMSettings(
+        enabled=True,
+        visual_enabled=visual,
+        pdf_enabled=pdf,
+        provider="openai",
+        models=["gpt-4o"],
+        vision_models=["gpt-4o-mini"],
+        api_key="test-key",
+        base_url=None,
+        temperature=0.2,
+        max_output_tokens=None,
+        request_timeout=30.0,
+    )
+
+
+def _make_visual_differences():
+    """Return a minimal differences list matching what compare_images produces."""
+    dummy_page = type("P", (), {"page_number": 1})()
+    return [
+        {
+            "ref_page": dummy_page,
+            "cand_page": dummy_page,
+            "message": "diff on page 1",
+            "rectangles": [{"x": 0, "y": 0, "width": 10, "height": 10}],
+            "score": 0.25,
+            "threshold": 0.0,
+            "absolute_diff": np.zeros((4, 4), dtype=np.uint8),
+            "combined_diff": np.zeros((4, 4, 3), dtype=np.uint8),
+            "notes": ["sample-note"],
+        }
+    ]
+
+
+def _make_pdf_differences():
+    """Return a minimal differences list matching what compare_pdf_documents produces."""
+    return [
+        {
+            "facet": "metadata",
+            "description": "Metadata mismatch",
+            "details": {"modified": datetime.datetime.now().isoformat()},
+        }
+    ]
+
+
+def _fake_create(data, media_type):
+    """Mock for create_binary_content."""
+    return {"data": data, "media_type": media_type}
+
+
+def _fake_load_settings_visual(overrides):
+    return _dummy_settings(visual=True)
+
+
+def _fake_load_settings_pdf(overrides):
+    return _dummy_settings(pdf=True)
+
+
+# ===========================================================================
+# Part 1a: Visual compare LLM branches
+# ===========================================================================
+
+
+class TestVisualLLMBranches:
+    """Test all LLM decision branches for _handle_llm_for_visual_differences."""
+
+    def _call_handler(self, monkeypatch, decision_label, confidence=0.9, reason="ok"):
+        """Helper that calls the visual LLM handler with a mocked assess function."""
+        vt = VisualTest()
+        monkeypatch.setattr(visual_module, "load_llm_settings", _fake_load_settings_visual)
+
+        def fake_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            return LLMDecision(
+                decision=decision_label,
+                confidence=confidence,
+                reason=reason,
+            )
+
+        return vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={"llm_provider": "openai"},
+            notes=["test-note"],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=fake_assess,
+        )
+
+    def test_approve_decision(self, monkeypatch):
+        """APPROVE: LLM says images are acceptable despite pixel differences."""
+        result = self._call_handler(monkeypatch, LLMDecisionLabel.APPROVE)
+        assert result is not None
+        assert result.decision == LLMDecisionLabel.APPROVE
+        assert result.is_positive is True
+        assert result.confidence == 0.9
+
+    def test_reject_decision(self, monkeypatch):
+        """REJECT: LLM says images are truly different."""
+        result = self._call_handler(monkeypatch, LLMDecisionLabel.REJECT, reason="real diff")
+        assert result is not None
+        assert result.decision == LLMDecisionLabel.REJECT
+        assert result.is_positive is False
+
+    def test_flag_decision(self, monkeypatch):
+        """FLAG: LLM flags differences for manual review."""
+        result = self._call_handler(monkeypatch, LLMDecisionLabel.FLAG, reason="needs review")
+        assert result is not None
+        assert result.decision == LLMDecisionLabel.FLAG
+        assert result.is_positive is False
+
+    def test_assess_raises_exception_returns_none(self, monkeypatch):
+        """Error/timeout: assess function raises -> handler returns None (fallback)."""
+        vt = VisualTest()
+        monkeypatch.setattr(visual_module, "load_llm_settings", _fake_load_settings_visual)
+
+        def failing_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            raise RuntimeError("Timeout contacting LLM API")
+
+        result = vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=failing_assess,
+        )
+        assert result is None
+
+    def test_assess_raises_llm_dependency_error_returns_none(self, monkeypatch):
+        """LLMDependencyError during assess -> handler returns None."""
+        vt = VisualTest()
+        monkeypatch.setattr(visual_module, "load_llm_settings", _fake_load_settings_visual)
+
+        def failing_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            raise LLMDependencyError("Missing deps")
+
+        result = vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=failing_assess,
+        )
+        assert result is None
+
+    def test_visual_disabled_returns_none(self, monkeypatch):
+        """If visual_enabled is False in settings, handler returns None."""
+        vt = VisualTest()
+
+        def settings_disabled(overrides):
+            return _dummy_settings(visual=False)
+
+        monkeypatch.setattr(visual_module, "load_llm_settings", settings_disabled)
+
+        result = vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=lambda *a, **kw: None,
+        )
+        assert result is None
+
+    def test_settings_load_failure_returns_none(self, monkeypatch):
+        """If load_llm_settings raises, handler returns None."""
+        vt = VisualTest()
+
+        def settings_explode(overrides):
+            raise ValueError("bad config")
+
+        monkeypatch.setattr(visual_module, "load_llm_settings", settings_explode)
+
+        result = vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=lambda *a, **kw: None,
+        )
+        assert result is None
+
+    def test_summary_contains_reference_and_candidate(self, monkeypatch):
+        """The textual summary sent to the LLM contains file path info."""
+        vt = VisualTest()
+        monkeypatch.setattr(visual_module, "load_llm_settings", _fake_load_settings_visual)
+
+        captured = {}
+
+        def capture_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            captured["summary"] = textual_summary
+            return LLMDecision(decision=LLMDecisionLabel.APPROVE, confidence=0.8, reason="ok")
+
+        vt._handle_llm_for_visual_differences(
+            reference_image="path/to/ref.png",
+            candidate_image="path/to/cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=["extra-context"],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=capture_assess,
+        )
+        assert "path/to/ref.png" in captured["summary"]
+        assert "path/to/cand.png" in captured["summary"]
+
+    def test_attachments_created_from_diff_images(self, monkeypatch):
+        """PNG attachments are created for combined_diff and absolute_diff."""
+        vt = VisualTest()
+        monkeypatch.setattr(visual_module, "load_llm_settings", _fake_load_settings_visual)
+
+        captured = {}
+
+        def capture_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            captured["attachments"] = attachments
+            return LLMDecision(decision=LLMDecisionLabel.APPROVE, confidence=0.8, reason="ok")
+
+        vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=capture_assess,
+        )
+        # Should have attachments for combined_diff and absolute_diff
+        assert len(captured["attachments"]) >= 2
+        for att in captured["attachments"]:
+            assert att["media_type"] == "image/png"
+
+    def test_custom_prompt_forwarded(self, monkeypatch):
+        """Custom prompt is forwarded to the assess function."""
+        vt = VisualTest()
+        monkeypatch.setattr(visual_module, "load_llm_settings", _fake_load_settings_visual)
+
+        captured = {}
+
+        def capture_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            captured["prompt"] = system_prompt
+            return LLMDecision(decision=LLMDecisionLabel.APPROVE, confidence=0.8, reason="ok")
+
+        vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt="Be strict about fonts.",
+            create_binary_content_fn=_fake_create,
+            assess_visual_diff_fn=capture_assess,
+        )
+        assert captured["prompt"] == "Be strict about fonts."
+
+
+# ===========================================================================
+# Part 1b: PDF compare LLM branches
+# ===========================================================================
+
+
+class TestPdfLLMBranches:
+    """Test all LLM decision branches for _handle_llm_for_pdf_differences."""
+
+    def _call_handler(self, monkeypatch, tmp_path, decision_label, confidence=0.9, reason="ok"):
+        """Helper that calls the PDF LLM handler with a mocked assess function."""
+        pdf_test = PdfTest()
+        monkeypatch.setattr(pdf_module, "load_llm_settings", _fake_load_settings_pdf)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        def fake_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            return LLMDecision(
+                decision=decision_label,
+                confidence=confidence,
+                reason=reason,
+            )
+
+        return pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=["pdf-note"],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=fake_assess,
+        )
+
+    def test_approve_decision(self, monkeypatch, tmp_path):
+        """APPROVE: LLM says PDFs are acceptable."""
+        result = self._call_handler(monkeypatch, tmp_path, LLMDecisionLabel.APPROVE)
+        assert result is not None
+        assert result.decision == LLMDecisionLabel.APPROVE
+        assert result.is_positive is True
+
+    def test_reject_decision(self, monkeypatch, tmp_path):
+        """REJECT: LLM says PDFs are truly different."""
+        result = self._call_handler(
+            monkeypatch, tmp_path, LLMDecisionLabel.REJECT, reason="content mismatch"
+        )
+        assert result is not None
+        assert result.decision == LLMDecisionLabel.REJECT
+        assert result.is_positive is False
+
+    def test_flag_decision(self, monkeypatch, tmp_path):
+        """FLAG: LLM flags PDFs for manual review."""
+        result = self._call_handler(monkeypatch, tmp_path, LLMDecisionLabel.FLAG, reason="review")
+        assert result is not None
+        assert result.decision == LLMDecisionLabel.FLAG
+        assert result.is_positive is False
+
+    def test_assess_raises_exception_returns_none(self, monkeypatch, tmp_path):
+        """Error during assess -> handler returns None (fallback to baseline)."""
+        pdf_test = PdfTest()
+        monkeypatch.setattr(pdf_module, "load_llm_settings", _fake_load_settings_pdf)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        def failing_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            raise RuntimeError("Network error")
+
+        result = pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=failing_assess,
+        )
+        assert result is None
+
+    def test_assess_raises_llm_dependency_error_returns_none(self, monkeypatch, tmp_path):
+        """LLMDependencyError during assess -> handler returns None."""
+        pdf_test = PdfTest()
+        monkeypatch.setattr(pdf_module, "load_llm_settings", _fake_load_settings_pdf)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        def failing_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            raise LLMDependencyError("Missing openai package")
+
+        result = pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=failing_assess,
+        )
+        assert result is None
+
+    def test_pdf_disabled_returns_none(self, monkeypatch, tmp_path):
+        """If pdf_enabled is False in settings, handler returns None."""
+        pdf_test = PdfTest()
+
+        def settings_disabled(overrides):
+            return _dummy_settings(pdf=False)
+
+        monkeypatch.setattr(pdf_module, "load_llm_settings", settings_disabled)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        result = pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=lambda *a, **kw: None,
+        )
+        assert result is None
+
+    def test_settings_load_failure_returns_none(self, monkeypatch, tmp_path):
+        """If load_llm_settings raises, handler returns None."""
+        pdf_test = PdfTest()
+
+        def settings_explode(overrides):
+            raise ValueError("corrupt config")
+
+        monkeypatch.setattr(pdf_module, "load_llm_settings", settings_explode)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        result = pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=lambda *a, **kw: None,
+        )
+        assert result is None
+
+    def test_missing_reference_file_still_works(self, monkeypatch, tmp_path):
+        """If reference file does not exist, handler warns but still calls assess."""
+        pdf_test = PdfTest()
+        monkeypatch.setattr(pdf_module, "load_llm_settings", _fake_load_settings_pdf)
+
+        cand = tmp_path / "candidate.pdf"
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+        nonexistent_ref = str(tmp_path / "does_not_exist.pdf")
+
+        captured = {}
+
+        def capture_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            captured["attachments"] = attachments
+            return LLMDecision(decision=LLMDecisionLabel.APPROVE, confidence=0.7, reason="ok")
+
+        result = pdf_test._handle_llm_for_pdf_differences(
+            reference_document=nonexistent_ref,
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=capture_assess,
+        )
+        # Should still return a decision -- missing file is a warning, not fatal
+        assert result is not None
+        assert result.decision == LLMDecisionLabel.APPROVE
+        # Only 1 attachment (candidate) since reference was missing
+        assert len(captured["attachments"]) == 1
+
+    def test_summary_contains_difference_descriptions(self, monkeypatch, tmp_path):
+        """The textual summary sent to the LLM contains difference info."""
+        pdf_test = PdfTest()
+        monkeypatch.setattr(pdf_module, "load_llm_settings", _fake_load_settings_pdf)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        captured = {}
+
+        def capture_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            captured["summary"] = textual_summary
+            return LLMDecision(decision=LLMDecisionLabel.APPROVE, confidence=0.8, reason="ok")
+
+        pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=capture_assess,
+        )
+        assert "Metadata mismatch" in captured["summary"]
+        assert str(ref) in captured["summary"]
+
+    def test_pdf_attachments_contain_both_documents(self, monkeypatch, tmp_path):
+        """Both reference and candidate PDFs are attached."""
+        pdf_test = PdfTest()
+        monkeypatch.setattr(pdf_module, "load_llm_settings", _fake_load_settings_pdf)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        captured = {}
+
+        def capture_assess(settings, textual_summary, attachments, extra_messages, system_prompt):
+            captured["attachments"] = attachments
+            return LLMDecision(decision=LLMDecisionLabel.APPROVE, confidence=0.8, reason="ok")
+
+        pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=_fake_create,
+            assess_pdf_diff_fn=capture_assess,
+        )
+        assert len(captured["attachments"]) == 2
+        for att in captured["attachments"]:
+            assert att["media_type"] == "application/pdf"
+
+
+# ===========================================================================
+# Part 2: Helper function tests (_coerce_label_value, _decision_equals_flag)
+# ===========================================================================
+
+
+class TestDecisionHelpers:
+    """Test the coercion and flag-detection helpers used after LLM decisions."""
+
+    def test_coerce_label_from_enum(self):
+        from DocTest.VisualTest import _coerce_label_value
+
+        assert _coerce_label_value(LLMDecisionLabel.APPROVE) == "approve"
+        assert _coerce_label_value(LLMDecisionLabel.REJECT) == "reject"
+        assert _coerce_label_value(LLMDecisionLabel.FLAG) == "flag"
+
+    def test_coerce_label_from_string(self):
+        from DocTest.VisualTest import _coerce_label_value
+
+        assert _coerce_label_value("approve") == "approve"
+        assert _coerce_label_value("REJECT") == "REJECT"
+
+    def test_decision_equals_flag_with_enum(self):
+        from DocTest.VisualTest import _decision_equals_flag
+
+        assert _decision_equals_flag(LLMDecisionLabel.FLAG, LLMDecisionLabel) is True
+        assert _decision_equals_flag(LLMDecisionLabel.APPROVE, LLMDecisionLabel) is False
+
+    def test_decision_equals_flag_without_enum_cls(self):
+        from DocTest.VisualTest import _decision_equals_flag
+
+        assert _decision_equals_flag("flag", None) is True
+        assert _decision_equals_flag("approve", None) is False
+
+    def test_decision_equals_flag_pdf_module(self):
+        from DocTest.PdfTest import _decision_equals_flag
+
+        assert _decision_equals_flag(LLMDecisionLabel.FLAG, LLMDecisionLabel) is True
+        assert _decision_equals_flag(LLMDecisionLabel.REJECT, LLMDecisionLabel) is False
+
+
+# ===========================================================================
+# Part 3: Missing dependencies -- graceful degradation
+# ===========================================================================
+
+
+class TestMissingDependencies:
+    """Verify that missing LLM dependencies do not crash the comparison flow."""
+
+    def test_load_visual_llm_runtime_raises_on_missing_deps(self, monkeypatch):
+        """_load_visual_llm_runtime raises LLMDependencyError when deps missing."""
+        import DocTest.VisualTest as vmod
+
+        # Reset the cached runtime so the import is re-attempted
+        monkeypatch.setattr(vmod, "_VISUAL_LLM_RUNTIME", None)
+
+        import builtins
+
+        original_import = builtins.__import__
+
+        def block_llm_client(name, *args, **kwargs):
+            if "DocTest.llm.client" in name:
+                raise ModuleNotFoundError(f"No module named '{name}'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", block_llm_client)
+
+        with pytest.raises(LLMDependencyError):
+            vmod._load_visual_llm_runtime()
+
+    def test_load_pdf_llm_runtime_raises_on_missing_deps(self, monkeypatch):
+        """_load_pdf_llm_runtime raises LLMDependencyError when deps missing."""
+        import DocTest.PdfTest as pmod
+
+        monkeypatch.setattr(pmod, "_PDF_LLM_RUNTIME", None)
+
+        import builtins
+
+        original_import = builtins.__import__
+
+        def block_llm_client(name, *args, **kwargs):
+            if "DocTest.llm.client" in name:
+                raise ModuleNotFoundError(f"No module named '{name}'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", block_llm_client)
+
+        with pytest.raises(LLMDependencyError):
+            pmod._load_pdf_llm_runtime()
+
+    def test_handler_returns_none_when_create_binary_raises_dep_error(self, monkeypatch):
+        """If create_binary_content raises LLMDependencyError, handler returns None."""
+        vt = VisualTest()
+        monkeypatch.setattr(visual_module, "load_llm_settings", _fake_load_settings_visual)
+
+        def bomb_create(data, media_type):
+            raise LLMDependencyError("boom")
+
+        result = vt._handle_llm_for_visual_differences(
+            reference_image="ref.png",
+            candidate_image="cand.png",
+            differences=_make_visual_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=bomb_create,
+            assess_visual_diff_fn=lambda *a, **kw: None,
+        )
+        assert result is None
+
+    def test_pdf_handler_returns_none_when_create_binary_raises_dep_error(
+        self, monkeypatch, tmp_path
+    ):
+        """If create_binary_content raises LLMDependencyError for PDF, handler returns None."""
+        pdf_test = PdfTest()
+        monkeypatch.setattr(pdf_module, "load_llm_settings", _fake_load_settings_pdf)
+
+        ref = tmp_path / "reference.pdf"
+        cand = tmp_path / "candidate.pdf"
+        ref.write_bytes(b"%PDF-1.7\n%EOF")
+        cand.write_bytes(b"%PDF-1.7\n%EOF")
+
+        def bomb_create(data, media_type):
+            raise LLMDependencyError("missing openai")
+
+        result = pdf_test._handle_llm_for_pdf_differences(
+            reference_document=str(ref),
+            candidate_document=str(cand),
+            differences=_make_pdf_differences(),
+            overrides={},
+            notes=[],
+            custom_prompt=None,
+            create_binary_content_fn=bomb_create,
+            assess_pdf_diff_fn=lambda *a, **kw: None,
+        )
+        assert result is None
+
+
+# ===========================================================================
+# Part 4: LLMDecision model properties
+# ===========================================================================
+
+
+class TestLLMDecisionModel:
+    """Test the LLMDecision pydantic model behaviour."""
+
+    def test_is_positive_for_approve(self):
+        d = LLMDecision(decision=LLMDecisionLabel.APPROVE, reason="ok")
+        assert d.is_positive is True
+
+    def test_is_positive_for_reject(self):
+        d = LLMDecision(decision=LLMDecisionLabel.REJECT, reason="bad")
+        assert d.is_positive is False
+
+    def test_is_positive_for_flag(self):
+        d = LLMDecision(decision=LLMDecisionLabel.FLAG, reason="unsure")
+        assert d.is_positive is False
+
+    def test_extra_fields_ignored(self):
+        """Extra fields in LLM JSON response should not cause validation errors."""
+        d = LLMDecision(
+            decision=LLMDecisionLabel.APPROVE,
+            reason="ok",
+            confidence=0.95,
+            unexpected_field="should be ignored",
+        )
+        assert d.decision == LLMDecisionLabel.APPROVE
+        assert not hasattr(d, "unexpected_field")
+
+    def test_optional_fields_default_to_none(self):
+        d = LLMDecision(decision=LLMDecisionLabel.REJECT)
+        assert d.confidence is None
+        assert d.reason is None
+        assert d.notes is None

--- a/utest/test_printjobtests.py
+++ b/utest/test_printjobtests.py
@@ -1,5 +1,6 @@
 """Unit tests for PrintJobTests module."""
 
+import os
 from unittest.mock import MagicMock, mock_open, patch
 
 from DocTest.PrintJobTests import (
@@ -7,9 +8,16 @@ from DocTest.PrintJobTests import (
     PostscriptVisitor,
     PrintJob,
     chop,
+    compare_print_jobs,
     get_pcl_print_job,
     get_postscript_print_job,
 )
+
+TESTDATA_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "testdata"
+)
+INVOICE_PS = os.path.join(TESTDATA_DIR, "invoice.ps")
+INVOICE_NO_LOGO_PS = os.path.join(TESTDATA_DIR, "invoice_no_logo.ps")
 
 
 class TestPrintJobFromPrintJobTests:
@@ -353,48 +361,62 @@ class TestGetPclPrintJob:
 
 
 class TestGetPostscriptPrintJob:
-    """Test cases for get_postscript_print_job function."""
+    """Test cases for get_postscript_print_job function using real fixture files."""
 
-    @patch("DocTest.PrintJobTests.is_url")
-    @patch(
-        "builtins.open", new_callable=mock_open, read_data="%!PS-Adobe-3.0\\n%%EOF\\n"
-    )
-    def test_get_postscript_print_job_local_file(self, mock_file, mock_is_url):
-        """Test getting PostScript print job from local file."""
-        mock_is_url.return_value = False
+    def test_get_postscript_print_job_invoice(self):
+        """Test parsing a real PostScript fixture (invoice.ps)."""
+        result = get_postscript_print_job(INVOICE_PS)
 
-        filename = "test.ps"
+        assert isinstance(result, PrintJob)
+        assert result.jobtype == "postscript"
+        assert len(result.properties) > 0
 
-        try:
-            result = get_postscript_print_job(filename)
-            # If we get here, check that it's a PrintJob
-            assert isinstance(result, PrintJob)
-            assert result.jobtype == "postscript"
-        except Exception:
-            # Expected due to simplified test content
-            pass
+        # Verify expected property keys exist
+        property_names = [p["property"] for p in result.properties]
+        assert "pjl_commands" in property_names
+        assert "pages" in property_names
+        assert "trailer" in property_names
 
-        mock_file.assert_called_once_with(filename, encoding="utf8", errors="ignore")
+    def test_get_postscript_print_job_invoice_no_logo(self):
+        """Test parsing a real PostScript fixture (invoice_no_logo.ps)."""
+        result = get_postscript_print_job(INVOICE_NO_LOGO_PS)
+
+        assert isinstance(result, PrintJob)
+        assert result.jobtype == "postscript"
+        assert len(result.properties) > 0
+
+        # Verify expected property keys exist
+        property_names = [p["property"] for p in result.properties]
+        assert "pjl_commands" in property_names
+        assert "pages" in property_names
+        assert "trailer" in property_names
+
+    def test_postscript_print_job_pages_parsed(self):
+        """Test that page metadata is correctly extracted from the fixture."""
+        result = get_postscript_print_job(INVOICE_PS)
+
+        pages_prop = next(
+            p for p in result.properties if p["property"] == "pages"
+        )
+        pages = pages_prop["value"]
+        assert len(pages) > 0
+        assert pages[0]["property"] == "PageBoundingBox"
+        assert pages[0]["page"] == "1"
+
+    def test_compare_postscript_print_jobs(self):
+        """Test comparing two real PostScript fixtures succeeds without error."""
+        # Both fixtures share the same page structure, so comparison should pass
+        compare_print_jobs("ps", INVOICE_PS, INVOICE_NO_LOGO_PS)
 
     @patch("DocTest.PrintJobTests.is_url")
     @patch("DocTest.PrintJobTests.download_file_from_url")
-    @patch(
-        "builtins.open", new_callable=mock_open, read_data="%!PS-Adobe-3.0\\n%%EOF\\n"
-    )
-    def test_get_postscript_print_job_url(self, mock_file, mock_download, mock_is_url):
-        """Test getting PostScript print job from URL."""
+    def test_get_postscript_print_job_url(self, mock_download, mock_is_url):
+        """Test that URL files are downloaded before parsing."""
         mock_is_url.return_value = True
-        mock_download.return_value = "downloaded_file.ps"
+        mock_download.return_value = INVOICE_PS
 
-        url = "http://example.com/test.ps"
+        result = get_postscript_print_job("http://example.com/test.ps")
 
-        try:
-            get_postscript_print_job(url)
-        except Exception:
-            # Expected due to simplified test content
-            pass
-
-        mock_download.assert_called_once_with(url)
-        mock_file.assert_called_once_with(
-            "downloaded_file.ps", encoding="utf8", errors="ignore"
-        )
+        mock_download.assert_called_once_with("http://example.com/test.ps")
+        assert isinstance(result, PrintJob)
+        assert result.jobtype == "postscript"


### PR DESCRIPTION
Address all critical, high, and medium risks identified in the riskstorming report. Key changes:

- Fix datamatrix ignore-area "y:" key typo causing masking failures
- Remove dead code from IgnoreAreaManager (crashed on self.opencv_images)
- Rewrite Downloader with proper URL parsing, GitHub blob→raw conversion, scheme validation, size limits, and HTML content detection
- Fix PostScript grammar to accept generic DSC comments, optional setup sections, and trailer data lines; real fixture tests replace mock stubs
- Replace 97 print() calls with robot.api.logger / logging across all modules for proper Robot Framework log integration
- Narrow 4 bare except: to specific types, document 33 broad handlers
- Add CapabilityCheck module with environment preflight detection for 7 capabilities (tesseract, ghostscript, ghostpcl, imagemagick, pymupdf, pyzbar, openai) and Robot Framework keyword
- Add 34 LLM mock tests covering all decision branches (approve/reject/flag/error/timeout/missing-deps)
- Add 11 performance benchmarks for load time, comparison, and memory

Test suite: 393 → 510 tests (+117), 0 failures, 3 skipped.