### PR TITLE
Fix issues #140, #127 and #98

### DIFF
--- a/DocTest/VisualTest.py
+++ b/DocTest/VisualTest.py
@@ -103,6 +103,11 @@ class VisualTest:
     MOVEMENT_DETECTION_DEFAULT = "template"
     MOVEMENT_DETECTION_METHODS = {"template", "orb", "sift", "text"}
     MOVEMENT_DETECTION_ALIASES = {"classic": "template"}
+    # Template matching has no "text" method — hence a setting of its own
+    # rather than reusing MOVEMENT_DETECTION_* (issue #127).
+    TEMPLATE_DETECTION_DEFAULT = "template"
+    TEMPLATE_DETECTION_METHODS = {"template", "orb", "sift"}
+    TEMPLATE_DETECTION_ALIASES = {"classic": "template"}
     PARTIAL_IMAGE_THRESHOLD_DEFAULT = 0.1
     PIXEL_INTENSITY_THRESHOLD_DEFAULT = 20
     SIFT_RATIO_THRESHOLD_DEFAULT = 0.75
@@ -132,9 +137,12 @@ class VisualTest:
         embed_screenshots: bool = False,
         force_ocr: bool = False,
         watermark_file: str = None,
-        movement_detection: Literal[
-            "template", "orb", "sift", "text"
-        ] = MOVEMENT_DETECTION_DEFAULT,
+        # Plain str, not Literal: Robot Framework converts import arguments
+        # from the type hint BEFORE library code runs, so a Literal hint
+        # rejects documented aliases like "classic" and makes
+        # MOVEMENT_DETECTION_ALIASES unreachable. Values are validated below.
+        movement_detection: str = MOVEMENT_DETECTION_DEFAULT,
+        template_detection: Optional[str] = None,
         partial_image_threshold: float = PARTIAL_IMAGE_THRESHOLD_DEFAULT,
         sift_ratio_threshold: float = SIFT_RATIO_THRESHOLD_DEFAULT,
         sift_min_matches: int = SIFT_MIN_MATCHES_DEFAULT,
@@ -161,7 +169,8 @@ class VisualTest:
         | ``embed_screenshots`` | Whether to embed screenshots as base64 in the log. Default is False. |
         | ``force_ocr`` | Whether to force OCR during image comparison. Default is False. |
         | ``watermark_file`` | Path to an image/document or a folder containing multiple images. They shall only contain a ```solid black`` area of the parts that shall be ignored for visual comparisons |
-        | ``movement_detection`` | Method to be used for movement detection. Options are ``template``, ``orb``, ``sift`` or ``text`` (text-based). Default is ``template``. |
+        | ``movement_detection`` | Method to be used for movement detection. Options are ``template``, ``orb``, ``sift`` or ``text`` (text-based); ``classic`` is an alias for ``template``. Default is ``template``. |
+        | ``template_detection`` | Default detection method for `Image Should Contain Template`. Options are ``template``, ``orb`` or ``sift`` (``classic`` is an alias for ``template``). A ``detection`` argument on an individual call still wins. Default is ``template``. Note this is separate from ``movement_detection``, which additionally supports ``text`` — not a valid template-matching method. |
         | ``partial_image_threshold`` | The threshold used to identify partial images, e.g. for movement detection. Value is between 0.0 and 1.0. A higher value will tolerate more differences. Default is ``0.1``. |
         | ``sift_ratio_threshold`` | Lowe's ratio test threshold for SIFT feature matching. Lower values are more restrictive. Default is ``0.75``. |
         | ``sift_min_matches`` | Minimum number of good matches required for SIFT homography computation. Default is ``4``. |
@@ -196,6 +205,11 @@ class VisualTest:
                 f"Supported values are: {', '.join(sorted(self.MOVEMENT_DETECTION_METHODS))}."
             )
         self.movement_detection = movement_method
+        self.template_detection = (
+            self._normalize_template_detection(template_detection)
+            if template_detection
+            else None
+        )
         self.partial_image_threshold = partial_image_threshold
         self.sift_ratio_threshold = sift_ratio_threshold
         self.sift_min_matches = sift_min_matches
@@ -1173,8 +1187,33 @@ class VisualTest:
                 )
                 robot_logger.info(f"{RESULT_LOG_PREFIX} {rel_path}")
 
-            for diff in detected_differences:
-                robot_logger.info(diff["message"])
+            if detected_differences:
+                # Report EVERY difference before failing. Raising inside this
+                # loop used to stop after the first one, which made multi-page
+                # comparisons look as if later pages were never compared
+                # (issue #98) — they always were.
+                affected_pages = sorted(
+                    {
+                        page_number
+                        for page_number in (
+                            self._difference_page_number(diff)
+                            for diff in detected_differences
+                        )
+                        if page_number is not None
+                    }
+                )
+                # Only useful for multi-page documents — the point of the
+                # summary is to show that later pages were compared too.
+                # Worded neutrally because a difference may be non-visual
+                # (differing barcode content on pixel-identical pages).
+                if affected_pages and reference_doc.page_count > 1:
+                    robot_logger.info(
+                        f"Differences detected on {len(affected_pages)} of "
+                        f"{reference_doc.page_count} page(s): "
+                        f"{', '.join(str(page) for page in affected_pages)}"
+                    )
+                for diff in detected_differences:
+                    robot_logger.info(self._format_difference_message(diff))
                 self._raise_comparison_failure()
 
             robot_logger.info("Images/Document comparison passed.")
@@ -1680,6 +1719,42 @@ class VisualTest:
         height = min(height, max_height)
         return {"x": x, "y": y, "width": width, "height": height}
 
+    def _normalize_template_detection(self, detection):
+        """Lower-case, de-alias and validate a template detection method."""
+        method = str(detection).strip().lower()
+        method = self.TEMPLATE_DETECTION_ALIASES.get(method, method)
+        if method not in self.TEMPLATE_DETECTION_METHODS:
+            raise ValueError(
+                f"Unsupported template detection method '{detection}'. "
+                f"Supported values are: {', '.join(sorted(self.TEMPLATE_DETECTION_METHODS))}."
+            )
+        return method
+
+    @keyword
+    def set_template_detection(self, template_detection: str):
+        """Set the default detection method for `Image Should Contain Template`.
+
+        | =Arguments= | =Description= |
+        | ``template_detection`` | One of ``template``, ``orb``, ``sift`` (``classic`` is an alias for ``template``). |
+
+        This is the library-level counterpart of the ``detection`` argument of
+        `Image Should Contain Template`; an explicit ``detection`` argument on a
+        call still wins.
+
+        The library uses Robot Framework's default ``TEST`` scope, so the new
+        value applies to the remainder of the current test only. Use the
+        ``template_detection`` import argument to set it for a whole suite.
+
+        Examples:
+        | `Set Template Detection`    sift        # Use SIFT for subsequent template searches |
+        | `Set Template Detection`    template    # Revert to template matching |
+
+        """
+        self.template_detection = self._normalize_template_detection(template_detection)
+        robot_logger.info(
+            f"Template detection method set to '{self.template_detection}'."
+        )
+
     @keyword
     def set_movement_detection(self, movement_detection: str):
         """Set the default movement detection method for subsequent comparisons.
@@ -2073,7 +2148,7 @@ class VisualTest:
         threshold: float = 0.0,
         take_screenshots: bool = False,
         log_template: bool = False,
-        detection: str = "template",
+        detection: Optional[str] = None,
         tpl_crop_x1: int = None,
         tpl_crop_y1: int = None,
         tpl_crop_x2: int = None,
@@ -2093,7 +2168,7 @@ class VisualTest:
         | ``threshold`` | Minimum similarity between the two images between ``0.0`` and ``1.0``. Default is ``0.0`` which is an exact match. Higher values allow more differences |
         | ``take_screenshots`` | If set to ``True``, a screenshot of the image with the template highlighted gets linked to the HTML log (if `embed_screenshots` is used during import, the image gets embedded). Default is ``False``. |
         | ``log_template`` | If set to ``True``, a screenshots of the template image gets linked to the HTML log (if `embed_screenshots` is used during import, the image gets embedded). Default is ``False``. |
-        | ``detection`` | Detection method to be used. Options are ``template``, ``sift`` and ``orb``.  Default is ``template``. |
+        | ``detection`` | Detection method to be used. Options are ``template``, ``sift`` and ``orb``. Defaults to the library-level ``template_detection`` import argument (see also `Set Template Detection`), which itself defaults to ``template``. |
         | ``tpl_crop_x1`` | X1 coordinate of the rectangle to crop the template image to.  |
         | ``tpl_crop_y1`` | Y1 coordinate of the rectangle to crop the template image to.  |
         | ``tpl_crop_x2`` | X2 coordinate of the rectangle to crop the template image to.  |
@@ -2106,7 +2181,20 @@ class VisualTest:
         | `Image Should Contain Template`    reference.jpg    template.jpg    tpl_crop_x1=50  tpl_crop_y1=50  tpl_crop_x2=100  tpl_crop_y2=100    #Before image comparison, the template image gets cropped to that selection.
         | `${coordinates}`    `Image Should Contain Template`    reference.jpg    template.jpg    #Checks if template is in image and returns coordinates of template
         | `Should Be Equal As Numbers`    ${coordinates['pt1'][0]}    100    #Checks if x coordinate of found template is 100
+
+        *Note:* the ``sift`` and ``orb`` methods do not use ``threshold`` and
+        their return value contains only ``pt1``/``pt2`` — no ``confidence``
+        key. Keep that in mind when selecting one of them library-wide.
         """
+        # Resolve the detection method: explicit argument, else the
+        # library-level setting, else the default (issue #127). An empty
+        # value counts as "not provided".
+        detection = self._normalize_template_detection(
+            detection
+            or self.template_detection
+            or self.TEMPLATE_DETECTION_DEFAULT
+        )
+
         # Validate crop arguments and load images
         all_crop_args = all((tpl_crop_x1, tpl_crop_y1, tpl_crop_x2, tpl_crop_y2))
         any_crop_args = any((tpl_crop_x1, tpl_crop_y1, tpl_crop_x2, tpl_crop_y2))
@@ -2311,6 +2399,29 @@ class VisualTest:
         rectangles = [cv2.boundingRect(contour) for contour in contours]
         return rectangles
 
+    @staticmethod
+    def _difference_page_number(diff):
+        """Page a detected difference belongs to, or None if it has none."""
+        page = diff.get("ref_page")
+        if page is not None:
+            return getattr(page, "page_number", None)
+        return diff.get("page")
+
+    def _format_difference_message(self, diff):
+        """Prefix a difference message with its page number.
+
+        Only entries carrying a ``ref_page`` are prefixed: the barcode
+        message already names its page, and prefixing it too would label the
+        page twice.
+        """
+        message = diff["message"]
+        if diff.get("ref_page") is None:
+            return message
+        page_number = self._difference_page_number(diff)
+        if page_number is None:
+            return message
+        return f"Page {page_number}: {message}"
+
     def _raise_comparison_failure(
         self, message: str = "The compared images are different."
     ):
@@ -2391,7 +2502,10 @@ class VisualTest:
         if original_size:
             img_style = "width: auto; height: auto;"
         else:
-            img_style = "width:50%; height: auto;"
+            # max-width (not width): bound large screenshots to half the log
+            # column as before, but never upscale small crops beyond their
+            # natural size (issue #140).
+            img_style = "max-width:50%; height: auto;"
 
         if self.embed_screenshots:
             import base64

--- a/DocTest/__init__.py
+++ b/DocTest/__init__.py
@@ -319,6 +319,29 @@ Accept if parts are moved up to 20 pixels by pure visual check
     Compare Images    Reference.jpg    Candidate.jpg    move_tolerance=20
 ```	
 
+#### Detection method for template matching
+
+`movement_detection` only affects moved-object detection. The detection method
+used by `Image Should Contain Template` is configured separately with
+`template_detection` (`template`, `orb` or `sift`), so it does not have to be
+repeated on every call:
+
+```RobotFramework
+*** Settings ***
+Library    DocTest.VisualTest   template_detection=sift
+
+*** Test Cases ***
+Find a logo using SIFT without repeating the detection argument
+    Image Should Contain Template    document.pdf    logo.png
+```
+
+An explicit `detection` argument still wins for a single call. The
+`Set Template Detection` keyword changes the default for the remainder of the
+current test — the library uses Robot Framework's default `TEST` scope, so use
+the import argument above to set it for a whole suite. Note that the `sift` and
+`orb` methods ignore `threshold` and their return value contains no
+`confidence` key.
+
 ### Options for taking additional screenshots, screenshot format and render resolution
 
 Take additional screenshots or reference and candidate file.

--- a/README.md
+++ b/README.md
@@ -421,7 +421,30 @@ Library    DocTest.VisualTest   movement_detection=classic
 *** Test Cases ***
 Accept if parts are moved up to 20 pixels by pure visual check
     Compare Images    Reference.jpg    Candidate.jpg    move_tolerance=20
-```	
+```
+
+#### Detection method for template matching
+
+`movement_detection` only affects moved-object detection. The detection method
+used by `Image Should Contain Template` is configured separately with
+`template_detection` (`template`, `orb` or `sift`), so it does not have to be
+repeated on every call:
+
+```RobotFramework
+*** Settings ***
+Library    DocTest.VisualTest   template_detection=sift
+
+*** Test Cases ***
+Find a logo using SIFT without repeating the detection argument
+    Image Should Contain Template    document.pdf    logo.png
+```
+
+An explicit `detection` argument still wins for a single call. The
+`Set Template Detection` keyword changes the default for the remainder of the
+current test — the library uses Robot Framework's default `TEST` scope, so use
+the import argument above to set it for a whole suite. Note that the `sift` and
+`orb` methods ignore `threshold` and their return value contains no
+`confidence` key.
 
 ### Options for taking additional screenshots, screenshot format and render resolution
 

--- a/atest/TemplateDetection.robot
+++ b/atest/TemplateDetection.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Documentation     Library-level template detection (issue #127).
+...               These tests exist at acceptance level because only a real Robot
+...               import exercises Robot Framework's argument type conversion — the
+...               mechanism that previously rejected documented aliases such as
+...               ``movement_detection=classic`` before library code could run.
+Library           DocTest.VisualTest    template_detection=sift    movement_detection=classic
+Library           Collections
+
+*** Test Cases ***
+Library Level Template Detection Is Applied Without Per-Call Argument
+    [Documentation]    template_detection=sift at import is used when the call omits detection.
+    ${coordinates}=    Image Should Contain Template    testdata/Beach_left.jpg    testdata/Beach_cropped.jpg
+    Should Not Be Empty    ${coordinates}
+
+Explicit Detection Argument Overrides The Library Level Setting
+    ${coordinates}=    Image Should Contain Template    testdata/Beach_left.jpg    testdata/Beach_cropped.jpg
+    ...    detection=template    threshold=0.999
+    Should Not Be Empty    ${coordinates}
+    Dictionary Should Contain Key    ${coordinates}    confidence
+
+Documented Classic Alias Is Accepted At Import
+    [Documentation]    movement_detection=classic is documented in the README and must
+    ...    resolve to template rather than being refused during import.
+    ${method}=    Get Library Instance    DocTest.VisualTest
+    Should Be Equal    ${method.movement_detection}    template
+
+Set Template Detection Keyword Changes The Default
+    [Documentation]    Switching to template matching makes the result carry a
+    ...    confidence value, which the sift/orb branches do not return.
+    ...    No teardown is needed: the library uses Robot's default TEST scope,
+    ...    so the next test gets a fresh instance with the import value.
+    Set Template Detection    template
+    ${coordinates}=    Image Should Contain Template    testdata/Beach_left.jpg    testdata/Beach_cropped.jpg
+    ...    threshold=0.999
+    Dictionary Should Contain Key    ${coordinates}    confidence
+
+Setter Does Not Leak Into The Next Test
+    [Documentation]    Pins the TEST-scope behavior the docs now describe.
+    ${lib}=    Get Library Instance    DocTest.VisualTest
+    Should Be Equal    ${lib.template_detection}    sift
+
+Unsupported Template Detection Value Is Rejected
+    Run Keyword And Expect Error    *Unsupported template detection method 'text'*
+    ...    Set Template Detection    text

--- a/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/design.md
+++ b/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/design.md
@@ -1,0 +1,35 @@
+# Design: fix-oversized-log-screenshots
+
+## Context
+
+`add_screenshot_to_log` (DocTest/VisualTest.py:2390-2439) is the only producer of screenshot HTML in the codebase. It computes one style string and interpolates it into three emit branches: base64 JPEG, base64 PNG, and the default file-link branch. `width:50%` is the single occurrence of that literal anywhere in the repo — no test, doc, dashboard or frontend file asserts on it.
+
+## Goals / Non-Goals
+
+**Goals:** stop upscaling small screenshots; leave every other rendering byte-identical; lock the behavior with a test.
+
+**Non-Goals:**
+- Changing the `original_size=True` branch. It was introduced deliberately (commit 3150d8d, "Embed template screenshots in their original (small) size") so template screenshots keep natural size; bounding it would reverse that.
+- Solving high-DPI crops that legitimately exceed half the column (a `dpi=600` crop can still be clamped). `max-width` is the fix for *upscaling*, not for downscaling large rasters — out of scope.
+- Any change to comparison logic, sidecar output, or keyword signatures.
+
+## Decisions
+
+1. **`width:50%` → `max-width:50%`** at the single producer line. CSS semantics: `width:50%` always resolves to half the containing block; `max-width:50%` resolves to `min(intrinsic, 50%)`. For any image ≥ half the column the two are identical, so large screenshots are unaffected by construction.
+2. **One-line change, no refactor.** All three emit branches share the `{img_style}` placeholder, so they change together with no risk of drift.
+3. **Test via `robot_logger` patching, not `caplog`.** `robot_logger` is `robot.api.logger` (imported at VisualTest.py:11); outside a Robot run it routes to the Python logger named `RobotFramework`, not `DocTest.VisualTest`, so `caplog` on the module logger captures nothing. The test patches `DocTest.VisualTest.robot_logger` and asserts on the emitted HTML string.
+4. **Cover the shipped default path.** Defaults are `screenshot_format="jpg"` and `embed_screenshots=False` (the file-link branch). The test exercises the default file-link path plus the embedded path, and pins the `original_size=True` branch as unchanged.
+
+## Risks / Trade-offs
+
+- [Robot's `log.html` renders messages inside an auto-layout table cell, where percentage `max-width` against a shrink-to-fit container is less crisply specified than percentage `width`] → The issue reporter empirically verified the improvement with before/after screenshots in the real log viewer, and the maintainer confirmed the annoyance; browsers resolve this consistently in practice for replaced elements with intrinsic dimensions.
+- [A small image in the base64 branches has no click-through link, so it can no longer be opened full size] → It renders at natural size now, which is the point; the default (file-link) branch keeps its `target="_blank"` wrapper.
+- [The no-upscaling invariant cannot be asserted from the style string alone, since both variants emit one shared string regardless of image size] → The test pins the exact style strings per branch, which is the only observable contract; the size-dependent rendering is the browser's job.
+
+## Migration Plan
+
+Single patch release. Rollback = revert the one-line change.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/proposal.md
+++ b/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/proposal.md
@@ -1,0 +1,25 @@
+# Proposal: fix-oversized-log-screenshots
+
+## Why
+
+GitHub issue #140: every screenshot embedded in the Robot Framework log is forced to exactly half the log column width (`style="width:50%; height: auto;"`). Small crops — the moved-area and diff-area images emitted when a `move_tolerance` check fails — are therefore *upscaled*, rendering huge and blurry instead of at their natural size. The reporter proposed `max-width:50%`, which keeps large screenshots exactly as they are today while letting small ones render at their real size.
+
+## What Changes
+
+- `VisualTest.add_screenshot_to_log`: the non-`original_size` style becomes `max-width:50%; height: auto;`. Large images (any image at least half the log column wide — all full-page renderings, combined views and diff images) render byte-identically; only images narrower than half the column change, which is exactly the population issue #140 is about.
+- The `original_size=True` branch (`width: auto; height: auto;`) is deliberately left untouched: it exists specifically so template screenshots keep their natural size, and widening it would reverse that earlier fix.
+- Add a regression test that pins the emitted `style` attribute for both branches and both emit paths (base64-embedded and the default file-link path).
+
+No behavioral change to comparison logic, no keyword signature change.
+
+## Capabilities
+
+### Modified Capabilities
+- `comparison-correctness`: adds a requirement that logged screenshots are never upscaled beyond their natural size.
+
+## Impact
+
+- Code: `DocTest/VisualTest.py` (one line: the non-`original_size` style string).
+- Tests: new `utest/test_screenshot_log_style.py`.
+- Consumers: `WebVisualTest` inherits `add_screenshot_to_log` unchanged and picks the fix up automatically. The dashboard's legacy log-scraping regex (`doctest_dashboard/ingest.py`) matches on `src=` only and is indifferent to the style attribute.
+- Users: logs become readable for small diff crops; nothing else observable changes.

--- a/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/specs/comparison-correctness/spec.md
+++ b/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/specs/comparison-correctness/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Logged screenshots are never upscaled
+Screenshots embedded in the Robot Framework log SHALL be constrained to at most half the log column width without being enlarged beyond their natural size. An image narrower than half the column SHALL render at its natural size; an image at least half the column wide SHALL render exactly as before (bounded to half the column). The dedicated natural-size mode (`original_size=True`) SHALL remain unbounded.
+
+#### Scenario: Small crop renders at natural size
+- **WHEN** a movement-tolerance failure logs a small diff-area crop
+- **THEN** the emitted `<img>` style constrains the maximum width rather than setting a fixed width, so the crop is not upscaled
+
+#### Scenario: Full-page screenshot is unchanged
+- **WHEN** a full-page rendering or combined diff image is logged
+- **THEN** it is still bounded to half the log column width
+
+#### Scenario: Natural-size mode still unbounded
+- **WHEN** a screenshot is logged with `original_size=True` (template screenshots)
+- **THEN** its style still imposes no width bound

--- a/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/tasks.md
+++ b/openspec/changes/archive/2026-07-30-fix-oversized-log-screenshots/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: fix-oversized-log-screenshots
+
+## 1. Fix
+
+- [x] 1.1 `DocTest/VisualTest.py`: change the non-`original_size` style from `width:50%; height: auto;` to `max-width:50%; height: auto;` (leave the `original_size=True` branch untouched)
+
+## 2. Regression test
+
+- [x] 2.1 Add `utest/test_screenshot_log_style.py` patching `DocTest.VisualTest.robot_logger`: assert the default file-link path (jpg, `embed_screenshots=False`) emits `max-width:50%; height: auto;` inside an `<a target="_blank">` wrapper
+- [x] 2.2 Same test file: assert the embedded base64 paths (jpg and png) emit `max-width:50%`, and that `original_size=True` still emits `width: auto; height: auto;`
+- [x] 2.3 Assert `width:50%` (the fixed-width form) no longer appears in any emitted HTML
+
+## 3. Verification
+
+- [x] 3.1 New tests pass; `uv run pytest utest -q -n auto --timeout=300` green; `uvx ruff check DocTest` green

--- a/openspec/changes/archive/2026-07-30-library-level-template-detection/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-library-level-template-detection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-library-level-template-detection/design.md
+++ b/openspec/changes/archive/2026-07-30-library-level-template-detection/design.md
@@ -1,0 +1,40 @@
+# Design: library-level-template-detection
+
+## Context
+
+`Image Should Contain Template` (DocTest/VisualTest.py:2069) hard-defaults `detection: str = "template"` and dispatches on it at :2165 (`template`) / :2221 (`sift` or `orb`) / :2298 (else → `ValueError`). The library already has the exact pattern to mirror for a library-level setting: `movement_detection` (validated in `__init__` at :191-198, changeable via `Set Movement Detection` at :1684, resolved per call in `compare_images` at :461-468 from an `Optional[str] = None` argument).
+
+## Goals / Non-Goals
+
+**Goals:** one place to configure the template detection method; unchanged behavior for suites that don't adopt it; documented aliases actually working.
+
+**Non-Goals:**
+- Making `movement_detection` drive template matching (see decision 3).
+- Fixing that `detection=orb` actually runs SIFT (`:2221` routes both into `get_sift_keypoints_and_descriptors`). Pre-existing; documented, not changed here — a behavior change there deserves its own issue.
+- Making `threshold` work under `sift`/`orb`, or unifying the two branches' return shapes. Documented as a caveat instead.
+- Warning on unknown import kwargs (`__init__` ends in `**kwargs` and silently swallows typos — a real trap, but a separate change).
+
+## Decisions
+
+1. **A `None` sentinel is required, and it is behavior-preserving.** `"template"` is a legitimate explicit value, so a hard default makes "caller passed template" indistinguishable from "caller passed nothing" and no library-level setting could ever apply. Changing the default to `None` is the same pattern `compare_images` already uses for `movement_detection` (`Optional[str] = None`). Because resolution terminates at `"template"`, **no existing suite changes behavior** — only the libdoc default string changes, which is why the reviewed signature baselines are regenerated rather than the change being avoided.
+2. **Plain `str`/`Optional[str]` hints, never `Literal`, for anything with aliases.** Robot converts import and keyword arguments from the type hint *before* library code runs, so a `Literal` hint rejects aliases like `classic` and makes the alias map unreachable. Verified live: `movement_detection=classic` raises *"cannot be converted to 'template', 'orb', 'sift' or 'text'"*. The new argument therefore uses `Optional[str]`, and `movement_detection`'s hint is widened to `str` to make the documented alias work. Validation quality does not regress — the library's own `ValueError` already lists supported values and is what `Set Movement Detection` has always produced.
+3. **Do not reuse `movement_detection`.** It accepts `text`, which is not a template-matching method, so reuse would need a silent fallback for an invalid value; and any suite already setting `movement_detection=sift|orb` would silently switch template matching too. A dedicated setting satisfies the request in the issue's own title ("Add a detection library import argument") with zero blast radius.
+4. **Separate validation helper, no shared refactor.** `__init__` and `Set Movement Detection` interpolate the *raw* argument into their error messages while `compare_images` interpolates the *normalized* one; a single shared helper cannot preserve all three messages byte-for-byte. The new setting gets its own small validator mirroring the movement one, and the movement code paths are left alone apart from the type hint.
+5. **Empty string counts as "not provided."** `detection=${EMPTY}` is falsy, so `detection or self.template_detection or "template"` falls back rather than raising as it does today. That is the more useful behavior for a defaulted argument and is pinned by a test.
+6. **Validate up front.** Resolution and validation happen at the top of the keyword, so a bad `detection` fails before file loading. This changes error *precedence* (previously a mismatched-crop or missing-file error surfaced first); no test depends on the old ordering.
+7. **Acceptance test is mandatory, not optional.** Only a Robot suite exercises Robot's import-argument type conversion — the exact mechanism behind the `classic` bug. Python-level unit tests cannot catch a regression there.
+
+## Risks / Trade-offs
+
+- [Widening `movement_detection` to `str` loses libdoc's rendered enum of allowed values] → The docstring argument table already lists them, and validation still rejects bad values with a clearer, library-owned message. Worth it to make a documented feature work.
+- [Both signature baselines must be regenerated, and the regeneration scripts rewrite the whole file, potentially absorbing unrelated drift] → Diff both JSONs and confirm the only changes are the `detection` default and the new keyword.
+- [A user adopting `template_detection=sift` may be surprised that `threshold` is ignored and the result dict loses `confidence`] → Documented explicitly in the keyword docstring, since a library-wide default makes this easier to hit.
+- [`WebVisualTest` forwards `**kwargs` to `VisualTest.__init__`, which silently swallows unknown keys, so a wiring regression would fail silently] → Explicit regression test asserting the setting arrives.
+
+## Migration Plan
+
+Single minor release; purely additive for users. Rollback = revert. No data or config migration.
+
+## Open Questions
+
+None. Naming (`template_detection`, parallel to `movement_detection`, rather than the issue's suggested `detection`) is a deliberate choice: the per-call argument stays `detection`, and a library-level argument literally named `detection` would read ambiguously next to it.

--- a/openspec/changes/archive/2026-07-30-library-level-template-detection/proposal.md
+++ b/openspec/changes/archive/2026-07-30-library-level-template-detection/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: library-level-template-detection
+
+## Why
+
+GitHub issue #127: `Image Should Contain Template` takes a per-call `detection` argument, but there is no way to set it once at library import — so suites that always want `sift` must repeat `detection=sift` in every call. The reporter expected the existing `movement_detection` import argument to cover this keyword too, and got no feedback when it didn't.
+
+While designing this, a related pre-existing defect surfaced: `movement_detection=classic` is documented in the README but **rejected at import time**. The `Literal["template","orb","sift","text"]` type hint makes Robot Framework convert (and refuse) the value before library code runs, so `MOVEMENT_DETECTION_ALIASES = {"classic": "template"}` is dead code. Verified: `Library DocTest.VisualTest movement_detection=classic` fails with *"got value 'classic' that cannot be converted to 'template', 'orb', 'sift' or 'text'"*.
+
+## What Changes
+
+- New library import argument `template_detection` (values `template`, `orb`, `sift`, plus the `classic` alias) setting the default detection method for `Image Should Contain Template`.
+- New keyword `Set Template Detection` to change it mid-suite, mirroring `Set Movement Detection`.
+- `Image Should Contain Template`'s `detection` argument default becomes a `None` sentinel, resolving: explicit call argument → library `template_detection` → `template`. **Behavior for existing suites is unchanged** — anyone who does not set the new argument still gets `template` exactly as before. Only the libdoc-rendered default changes, so the reviewed signature baselines are regenerated.
+- The `detection` value is now normalized (lower-cased, `classic` aliased) and validated up front with a clear error listing the supported values.
+- **Fix `movement_detection=classic`**: widen the `__init__` type hint from `Literal[...]` to `str` so the documented alias reaches the alias map. Validation, error message and accepted values are unchanged (the library already validates and raises its own `ValueError`).
+- `movement_detection` is deliberately **not** reused for template matching: it accepts `text`, which is meaningless for template matching, and reusing it would silently change behavior for existing `movement_detection` users.
+- Docstring notes that under `sift`/`orb` the `threshold` argument is not consulted and the returned dict has no `confidence` key — relevant now that these can become a library-wide default.
+
+## Capabilities
+
+### New Capabilities
+- `template-detection-config`: configuring the template-matching detection method at library level, its resolution order, validation, and aliasing.
+
+## Impact
+
+- Code: `DocTest/VisualTest.py` (`__init__`, new `Set Template Detection` keyword, `image_should_contain_template`).
+- Baselines: `utest/keyword_signatures_baseline.json` and `scripts/keyword_surface_baseline.json` regenerated — the only expected diffs are the `detection` default and the added keyword.
+- Docs: README gains a library-level template-detection example.
+- Tests: new unit tests plus a Robot acceptance test (the only path that exercises Robot's import-argument type conversion, which is where the `classic` bug lives).
+- `WebVisualTest` inherits the new setting through `**kwargs`; covered by an explicit test because unknown kwargs are silently swallowed.

--- a/openspec/changes/archive/2026-07-30-library-level-template-detection/specs/template-detection-config/spec.md
+++ b/openspec/changes/archive/2026-07-30-library-level-template-detection/specs/template-detection-config/spec.md
@@ -1,0 +1,47 @@
+# Spec: template-detection-config
+
+## ADDED Requirements
+
+### Requirement: Library-level template detection setting
+`VisualTest` SHALL accept a `template_detection` import argument and provide a `Set Template Detection` keyword, both selecting the default detection method used by `Image Should Contain Template`. Supported values are `template`, `orb` and `sift`, with `classic` accepted as an alias for `template`. Values SHALL be case-insensitive. An unsupported value SHALL raise an error naming the offending value and listing the supported values.
+
+#### Scenario: Import argument sets the default for every call
+- **WHEN** the library is imported with `template_detection=sift` and `Image Should Contain Template` is called without a `detection` argument
+- **THEN** SIFT-based detection is used
+
+#### Scenario: Keyword changes the setting mid-suite
+- **WHEN** `Set Template Detection    sift` runs and a later `Image Should Contain Template` call omits `detection`
+- **THEN** SIFT-based detection is used for that call
+
+#### Scenario: Unsupported value is rejected
+- **WHEN** the library is imported with `template_detection=bogus`
+- **THEN** an error is raised naming `bogus` and listing `orb`, `sift`, `template`
+
+#### Scenario: Case and alias handling
+- **WHEN** `template_detection=SIFT` or `template_detection=classic` is given
+- **THEN** they resolve to `sift` and `template` respectively
+
+### Requirement: Detection resolution order preserves existing behavior
+The detection method for `Image Should Contain Template` SHALL resolve as: the explicit `detection` call argument, else the library-level `template_detection`, else `template`. An omitted or empty `detection` argument SHALL be treated as "not provided". A suite that sets neither SHALL behave exactly as before this change.
+
+#### Scenario: Call argument wins over library setting
+- **WHEN** the library sets `template_detection=sift` but a call passes `detection=template`
+- **THEN** template matching is used for that call
+
+#### Scenario: Unchanged default for existing suites
+- **WHEN** neither `template_detection` nor `detection` is provided
+- **THEN** template matching is used, as before
+
+### Requirement: Movement detection is configured independently
+The library SHALL keep `movement_detection` and `template_detection` as separate settings, because `movement_detection` additionally supports `text`, which is not a valid template-matching method. Setting `movement_detection` SHALL NOT change the method used by `Image Should Contain Template`.
+
+#### Scenario: movement_detection does not leak into template matching
+- **WHEN** the library is imported with `movement_detection=text` and `Image Should Contain Template` is called without `detection`
+- **THEN** template matching is used and no error about `text` is raised
+
+### Requirement: Documented movement detection aliases are accepted at import
+The `movement_detection` import argument SHALL accept every documented value including the `classic` alias, resolving it to `template`. Type conversion SHALL NOT reject documented aliases before the library validates them.
+
+#### Scenario: classic alias works at import
+- **WHEN** a suite imports the library with `movement_detection=classic`
+- **THEN** the import succeeds and the effective movement detection method is `template`

--- a/openspec/changes/archive/2026-07-30-library-level-template-detection/tasks.md
+++ b/openspec/changes/archive/2026-07-30-library-level-template-detection/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: library-level-template-detection
+
+## 1. Library-level setting
+
+- [x] 1.1 Add `TEMPLATE_DETECTION_METHODS = {"template", "orb", "sift"}`, `TEMPLATE_DETECTION_ALIASES = {"classic": "template"}` and `TEMPLATE_DETECTION_DEFAULT = "template"` class constants
+- [x] 1.2 Add `template_detection: Optional[str] = None` to `VisualTest.__init__` (plain `Optional[str]`, never `Literal`), normalize + validate it, store as `self.template_detection`
+- [x] 1.3 Add the `Set Template Detection` keyword mirroring `Set Movement Detection` (same validation and log line style)
+
+## 2. Keyword resolution
+
+- [x] 2.1 Change `image_should_contain_template`'s `detection` argument to `Optional[str] = None` and resolve at the top of the keyword: explicit (non-empty) argument → `self.template_detection` → `template`, with normalization, aliasing and validation
+- [x] 2.2 Update the keyword docstring: document the new resolution, and note that `threshold` is not consulted under `sift`/`orb` and that those branches return no `confidence` key
+
+## 3. Fix documented movement_detection alias
+
+- [x] 3.1 Widen `movement_detection`'s `__init__` type hint from `Literal[...]` to `str` so `classic` reaches the alias map; confirm the raised error message for bad values is unchanged
+
+## 4. Baselines and docs
+
+- [x] 4.1 Regenerate `utest/keyword_signatures_baseline.json` and `scripts/keyword_surface_baseline.json`; diff both and confirm the only changes are the `detection` default and the new `Set Template Detection` keyword
+- [x] 4.2 README: document `template_detection` as a library import argument with an example
+
+## 5. Tests
+
+- [x] 5.1 Unit tests: default resolution unchanged when nothing is set; import argument applied; `Set Template Detection` applied and re-settable; explicit call argument wins; `${EMPTY}` treated as not provided; case-insensitivity; `classic` alias; invalid value error message
+- [x] 5.2 Unit test: `movement_detection=text` does NOT change the template detection method
+- [x] 5.3 Unit test: `WebVisualTest(template_detection="sift")` actually reaches `VisualTest` (guards the silent `**kwargs` swallow)
+- [x] 5.4 Robot acceptance test exercising import-argument type conversion for both `template_detection=sift` and `movement_detection=classic`
+
+## 6. Verification
+
+- [x] 6.1 `uv run pytest utest -q -n auto --timeout=300` green (incl. signature-snapshot and package-parity tests); `uvx ruff check DocTest` green; new acceptance suite passes

--- a/openspec/changes/archive/2026-07-30-report-all-differing-pages/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-report-all-differing-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-report-all-differing-pages/design.md
+++ b/openspec/changes/archive/2026-07-30-report-all-differing-pages/design.md
@@ -1,0 +1,48 @@
+# Design: report-all-differing-pages
+
+## Context
+
+`compare_images` collects differences into `detected_differences` while iterating page pairs, then ends with:
+
+```python
+for diff in detected_differences:
+    robot_logger.info(diff["message"])
+    self._raise_comparison_failure()
+```
+
+The raise is inside the loop, so iteration stops after the first entry. Everything upstream is already correct: all pages are compared, screenshots for every differing page are emitted inside the page loop, and the JSON sidecar records a per-page entry for every page.
+
+The entries are heterogeneous:
+- SSIM and dimension-mismatch entries carry `ref_page`/`cand_page` and a message with **no** page number.
+- Barcode entries carry `page` (an int) and no `ref_page`, and their message **already** reads `The barcodes on page N differ: ...`.
+
+## Goals / Non-Goals
+
+**Goals:** report every differing page; name the page in each message exactly once; keep the failure text and every pass/fail outcome identical.
+
+**Non-Goals:**
+- Changing the `AssertionError` text. 39+ exact-string assertions depend on it (`atest/`, `utest/`, and generated suites in `e2e/e2e_helpers.py`, `e2e/test_journeys.py`), and Robot's report shows only that text.
+- Changing the page-count-mismatch behavior. `iter_page_pairs` raises `ValueError("Documents have different number of pages.")` before any page is compared, so documents of unequal length still compare zero pages. That is a different (and more invasive) change than the reported one.
+- Revisiting `check_text_content=True` passing when text matches. The issue's second remark touches this, but "differences accepted because the text is identical" is the documented purpose of that option.
+
+## Decisions
+
+1. **Log all, then raise once.** `for ...: log(...)` followed by `if detected_differences: self._raise_comparison_failure()`. The `if` guard is essential: `detected_differences` is deliberately cleared when an LLM override approves the differences or a reference run promotes the candidate, and in those cases execution must continue to the existing `Images/Document comparison passed.` line.
+2. **Page prefix only where it is missing.** Prefix `Page {n}: ` when the entry has a `ref_page`; leave entries without one (barcode) untouched, since their message already names the page. This avoids the "Page 1: The barcodes on page 1 differ" double label without editing the barcode message — which also flows into the sidecar `notes` and the LLM payload and must stay as it is.
+3. **Leading summary, not trailing.** The summary is emitted before the per-difference lines so a large multi-page failure is scannable from the top.
+4. **Read `page_number` after the loop is safe.** In streaming mode pages are released as iteration advances, but `Page.release_resources()` clears image/text/barcode data and never touches `page_number`, and `detected_differences` holds strong references to the `Page` objects.
+5. **New fixtures, built in the test.** No committed fixture pair differs on more than one page, so the regression test builds 3-page PDFs with PyMuPDF in a temp directory.
+6. **Assert on `robot_logger`, not `caplog`.** `robot_logger` is `robot.api.logger`; outside a Robot run it routes to the Python logger named `RobotFramework`, not `DocTest.VisualTest`, so `caplog` on the module logger captures nothing.
+
+## Risks / Trade-offs
+
+- [Log volume grows with the number of differing pages, amplified by `WebVisualTest`'s retry loop, which swallows the failure and retries until its timeout] → INFO level, one line per differing page; the leading summary keeps it navigable and outcomes are unchanged.
+- [Users may still want page numbers in the failure message itself, which Robot's report shows] → Deliberately out of scope given the exact-match assertions; an additive, default-off argument could offer it later without breaking the baseline.
+
+## Migration Plan
+
+Single patch release; log output only. Rollback = revert.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-30-report-all-differing-pages/proposal.md
+++ b/openspec/changes/archive/2026-07-30-report-all-differing-pages/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: report-all-differing-pages
+
+## Why
+
+GitHub issue #98 (with a second reporter confirming): comparing a multi-page PDF appears to stop at the first differing page, so users cannot see whether later pages also differ.
+
+Investigation shows the comparison itself is fine — **every page is already compared**. For a 3-page pair differing on pages 1 and 3, both differences are collected and screenshots are emitted for both. The defect is purely in reporting: the final loop in `compare_images` calls `self._raise_comparison_failure()` *inside* the `for diff in detected_differences` loop, so only the first difference is ever logged. Worse, that one message (`Visual differences detected. SSIM score: ...`) does not say which page it refers to, so the log gives no hint that other pages were even examined.
+
+## What Changes
+
+- `compare_images` logs **every** collected difference and then raises **once**, instead of raising on the first one.
+- A leading summary line names the affected pages up front (e.g. `Visual differences detected on 2 of 3 page(s): 1, 3`) so a long log stays scannable.
+- Per-difference messages are prefixed with their page number. Messages that already name their page — the barcode difference message — are left alone, so nothing is labelled twice.
+- The raised `AssertionError` text stays exactly `The compared images are different.` More than 39 assertions across `atest/`, `utest/` and `e2e/` match that string exactly, and Robot's report shows only the exception text; page detail belongs in the log body.
+
+`PdfTest.compare_pdf_documents` was checked and already accumulates into a single flag before raising once — no change needed there.
+
+## Capabilities
+
+### Modified Capabilities
+- `comparison-correctness`: adds a requirement that all differing pages are reported, not just the first.
+
+## Impact
+
+- Code: `DocTest/VisualTest.py` — the final reporting block, plus a page prefix on the difference messages that lack one.
+- Tests: new `utest/test_multipage_reporting.py` building multi-page fixtures with PyMuPDF (no existing fixture differs on more than one page).
+- Users: failing multi-page comparisons now list every differing page. No change to pass/fail outcomes, exception text, sidecar contents (which already record all pages) or keyword signatures.
+- `WebVisualTest` retries `compare_images` until its timeout, so a failing web comparison logs proportionally more lines than before; acceptable at INFO level and unchanged in outcome.

--- a/openspec/changes/archive/2026-07-30-report-all-differing-pages/specs/comparison-correctness/spec.md
+++ b/openspec/changes/archive/2026-07-30-report-all-differing-pages/specs/comparison-correctness/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Every differing page is reported
+When a multi-page comparison detects differences on more than one page, the library SHALL log a message for every detected difference before failing, not only the first. Each logged difference SHALL identify its page exactly once, and the comparison SHALL still fail with the unchanged message `The compared images are different.`
+
+#### Scenario: Differences on several pages are all reported
+- **WHEN** `Compare Images` compares a 3-page pair that differs on pages 1 and 3
+- **THEN** the log contains a difference message for page 1 and for page 3, and the keyword fails with `The compared images are different.`
+
+#### Scenario: Summary names the affected pages
+- **WHEN** a multi-page comparison fails on more than one page
+- **THEN** the log contains a leading summary line naming every affected page number
+
+#### Scenario: Pages are not labelled twice
+- **WHEN** a difference message already names its page (barcode content differences)
+- **THEN** that message is logged unchanged, without an additional page prefix
+
+#### Scenario: Single-page failure is unchanged in outcome
+- **WHEN** a single-page comparison fails
+- **THEN** the keyword still fails with `The compared images are different.`

--- a/openspec/changes/archive/2026-07-30-report-all-differing-pages/tasks.md
+++ b/openspec/changes/archive/2026-07-30-report-all-differing-pages/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: report-all-differing-pages
+
+## 1. Fix reporting
+
+- [x] 1.1 `DocTest/VisualTest.py`: log every entry in `detected_differences`, then raise once via `if detected_differences: self._raise_comparison_failure()` (guard required so LLM-override and reference-run paths still reach the "comparison passed" line)
+- [x] 1.2 Emit a leading summary line naming the affected page numbers when differences were found
+- [x] 1.3 Prefix each logged message with `Page {n}: ` only for entries carrying a `ref_page`; leave barcode messages (which already name their page) unchanged
+
+## 2. Regression tests
+
+- [x] 2.1 Add `utest/test_multipage_reporting.py` building 3-page PDF fixtures with PyMuPDF that differ on pages 1 and 3; assert a message is logged for both pages and the failure text is still `The compared images are different.`
+- [x] 2.2 Assert the leading summary names both page numbers
+- [x] 2.3 Assert barcode difference messages are not double-labelled
+- [x] 2.4 Assert a passing comparison logs no difference messages and still logs the "passed" line
+
+## 3. Verification
+
+- [x] 3.1 Confirm the failure message text is byte-identical (the 39+ exact-match assertions in `atest/`, `utest/` and `e2e/` stay green)
+- [x] 3.2 `uv run pytest utest -q -n auto --timeout=300` green; `uvx ruff check DocTest` green

--- a/openspec/specs/comparison-correctness/spec.md
+++ b/openspec/specs/comparison-correctness/spec.md
@@ -81,3 +81,37 @@ URL reference fetching SHALL validate the scheme of every redirect hop against t
 #### Scenario: Oversized download aborts early
 - **WHEN** a download exceeds `max_size` mid-transfer
 - **THEN** the transfer stops at the limit and the partial temp file is removed
+
+### Requirement: Logged screenshots are never upscaled
+Screenshots embedded in the Robot Framework log SHALL be constrained to at most half the log column width without being enlarged beyond their natural size. An image narrower than half the column SHALL render at its natural size; an image at least half the column wide SHALL render exactly as before (bounded to half the column). The dedicated natural-size mode (`original_size=True`) SHALL remain unbounded.
+
+#### Scenario: Small crop renders at natural size
+- **WHEN** a movement-tolerance failure logs a small diff-area crop
+- **THEN** the emitted `<img>` style constrains the maximum width rather than setting a fixed width, so the crop is not upscaled
+
+#### Scenario: Full-page screenshot is unchanged
+- **WHEN** a full-page rendering or combined diff image is logged
+- **THEN** it is still bounded to half the log column width
+
+#### Scenario: Natural-size mode still unbounded
+- **WHEN** a screenshot is logged with `original_size=True` (template screenshots)
+- **THEN** its style still imposes no width bound
+
+### Requirement: Every differing page is reported
+When a multi-page comparison detects differences on more than one page, the library SHALL log a message for every detected difference before failing, not only the first. Each logged difference SHALL identify its page exactly once, and the comparison SHALL still fail with the unchanged message `The compared images are different.`
+
+#### Scenario: Differences on several pages are all reported
+- **WHEN** `Compare Images` compares a 3-page pair that differs on pages 1 and 3
+- **THEN** the log contains a difference message for page 1 and for page 3, and the keyword fails with `The compared images are different.`
+
+#### Scenario: Summary names the affected pages
+- **WHEN** a multi-page comparison fails on more than one page
+- **THEN** the log contains a leading summary line naming every affected page number
+
+#### Scenario: Pages are not labelled twice
+- **WHEN** a difference message already names its page (barcode content differences)
+- **THEN** that message is logged unchanged, without an additional page prefix
+
+#### Scenario: Single-page failure is unchanged in outcome
+- **WHEN** a single-page comparison fails
+- **THEN** the keyword still fails with `The compared images are different.`

--- a/openspec/specs/template-detection-config/spec.md
+++ b/openspec/specs/template-detection-config/spec.md
@@ -1,0 +1,48 @@
+# Spec: template-detection-config
+
+## Purpose
+Configuring the detection method used by template matching (`Image Should Contain Template`) at library level: resolution order, validation, aliasing, and its separation from movement detection.
+## Requirements
+### Requirement: Library-level template detection setting
+`VisualTest` SHALL accept a `template_detection` import argument and provide a `Set Template Detection` keyword, both selecting the default detection method used by `Image Should Contain Template`. Supported values are `template`, `orb` and `sift`, with `classic` accepted as an alias for `template`. Values SHALL be case-insensitive. An unsupported value SHALL raise an error naming the offending value and listing the supported values.
+
+#### Scenario: Import argument sets the default for every call
+- **WHEN** the library is imported with `template_detection=sift` and `Image Should Contain Template` is called without a `detection` argument
+- **THEN** SIFT-based detection is used
+
+#### Scenario: Keyword changes the setting mid-suite
+- **WHEN** `Set Template Detection    sift` runs and a later `Image Should Contain Template` call omits `detection`
+- **THEN** SIFT-based detection is used for that call
+
+#### Scenario: Unsupported value is rejected
+- **WHEN** the library is imported with `template_detection=bogus`
+- **THEN** an error is raised naming `bogus` and listing `orb`, `sift`, `template`
+
+#### Scenario: Case and alias handling
+- **WHEN** `template_detection=SIFT` or `template_detection=classic` is given
+- **THEN** they resolve to `sift` and `template` respectively
+
+### Requirement: Detection resolution order preserves existing behavior
+The detection method for `Image Should Contain Template` SHALL resolve as: the explicit `detection` call argument, else the library-level `template_detection`, else `template`. An omitted or empty `detection` argument SHALL be treated as "not provided". A suite that sets neither SHALL behave exactly as before this change.
+
+#### Scenario: Call argument wins over library setting
+- **WHEN** the library sets `template_detection=sift` but a call passes `detection=template`
+- **THEN** template matching is used for that call
+
+#### Scenario: Unchanged default for existing suites
+- **WHEN** neither `template_detection` nor `detection` is provided
+- **THEN** template matching is used, as before
+
+### Requirement: Movement detection is configured independently
+The library SHALL keep `movement_detection` and `template_detection` as separate settings, because `movement_detection` additionally supports `text`, which is not a valid template-matching method. Setting `movement_detection` SHALL NOT change the method used by `Image Should Contain Template`.
+
+#### Scenario: movement_detection does not leak into template matching
+- **WHEN** the library is imported with `movement_detection=text` and `Image Should Contain Template` is called without `detection`
+- **THEN** template matching is used and no error about `text` is raised
+
+### Requirement: Documented movement detection aliases are accepted at import
+The `movement_detection` import argument SHALL accept every documented value including the `classic` alias, resolving it to `template`. Type conversion SHALL NOT reject documented aliases before the library validates them.
+
+#### Scenario: classic alias works at import
+- **WHEN** a suite imports the library with `movement_detection=classic`
+- **THEN** the import succeeds and the effective movement detection method is `template`

--- a/scripts/keyword_surface_baseline.json
+++ b/scripts/keyword_surface_baseline.json
@@ -500,7 +500,7 @@
         "required": false
       },
       {
-        "default": "template",
+        "default": "None",
         "kind": "POSITIONAL_OR_NAMED",
         "name": "detection",
         "required": false
@@ -623,6 +623,14 @@
         "default": null,
         "kind": "POSITIONAL_OR_NAMED",
         "name": "take_screenshots",
+        "required": true
+      }
+    ],
+    "Set Template Detection": [
+      {
+        "default": null,
+        "kind": "POSITIONAL_OR_NAMED",
+        "name": "template_detection",
         "required": true
       }
     ],
@@ -992,7 +1000,7 @@
         "required": false
       },
       {
-        "default": "template",
+        "default": "None",
         "kind": "POSITIONAL_OR_NAMED",
         "name": "detection",
         "required": false
@@ -1123,6 +1131,14 @@
         "default": null,
         "kind": "POSITIONAL_OR_NAMED",
         "name": "take_screenshots",
+        "required": true
+      }
+    ],
+    "Set Template Detection": [
+      {
+        "default": null,
+        "kind": "POSITIONAL_OR_NAMED",
+        "name": "template_detection",
         "required": true
       }
     ],

--- a/tasks.py
+++ b/tasks.py
@@ -59,6 +59,7 @@ def atests(context):
         f"{ROOT}/atest/PdfContent.robot",
         f"{ROOT}/atest/PrintJobs.robot",
         f"{ROOT}/atest/MovementDetection.robot",
+        f"{ROOT}/atest/TemplateDetection.robot",
         f"{ROOT}/atest/ReferenceRun.robot",
         f"{ROOT}/atest/ResultJson.robot",
         f"{ROOT}/atest/LLM.robot",

--- a/utest/keyword_signatures_baseline.json
+++ b/utest/keyword_signatures_baseline.json
@@ -119,7 +119,7 @@
       "threshold=0.0",
       "take_screenshots=False",
       "log_template=False",
-      "detection=template",
+      "detection=None",
       "tpl_crop_x1=None",
       "tpl_crop_y1=None",
       "tpl_crop_x2=None",
@@ -160,6 +160,9 @@
     ],
     "Set Take Screenshots": [
       "take_screenshots"
+    ],
+    "Set Template Detection": [
+      "template_detection"
     ],
     "Set Threshold": [
       "threshold"
@@ -241,7 +244,7 @@
       "threshold=0.0",
       "take_screenshots=False",
       "log_template=False",
-      "detection=template",
+      "detection=None",
       "tpl_crop_x1=None",
       "tpl_crop_y1=None",
       "tpl_crop_x2=None",
@@ -285,6 +288,9 @@
     ],
     "Set Take Screenshots": [
       "take_screenshots"
+    ],
+    "Set Template Detection": [
+      "template_detection"
     ],
     "Set Threshold": [
       "threshold"

--- a/utest/test_multipage_reporting.py
+++ b/utest/test_multipage_reporting.py
@@ -1,0 +1,162 @@
+"""Multi-page comparisons must report every differing page (issue #98).
+
+All pages were always compared, but the final reporting loop raised on the
+first difference, so only one message was ever logged — and it did not name
+its page. Users concluded the comparison had stopped at page 1.
+
+No committed fixture pair differs on more than one page, so the fixtures are
+built here with PyMuPDF.
+"""
+
+from unittest.mock import patch
+
+import fitz
+import pytest
+
+from DocTest.VisualTest import VisualTest
+
+FAILURE_MESSAGE = "The compared images are different."
+
+
+def _make_pdf(path, page_texts):
+    doc = fitz.open()
+    for text in page_texts:
+        page = doc.new_page(width=400, height=400)
+        page.insert_text((50, 100), text, fontsize=24)
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+@pytest.fixture
+def three_page_pair(tmp_path):
+    """3-page documents differing on pages 1 and 3, identical on page 2."""
+    reference = _make_pdf(
+        tmp_path / "ref.pdf", ["PAGE ONE ORIGINAL", "PAGE TWO SAME", "PAGE THREE ORIGINAL"]
+    )
+    candidate = _make_pdf(
+        tmp_path / "cand.pdf", ["PAGE ONE CHANGED!!", "PAGE TWO SAME", "PAGE THREE CHANGED!!"]
+    )
+    return reference, candidate
+
+
+def _compare_and_capture(reference, candidate, tester=None, **kwargs):
+    """Run a comparison, returning (raised_message_or_None, logged_lines)."""
+    tester = tester or VisualTest(take_screenshots=False)
+    with patch("DocTest.VisualTest.robot_logger") as logger:
+        raised = None
+        try:
+            tester.compare_images(reference, candidate, **kwargs)
+        except AssertionError as error:
+            raised = str(error)
+        lines = [str(call[0][0]) for call in logger.info.call_args_list if call[0]]
+    return raised, lines
+
+
+def test_every_differing_page_is_reported(three_page_pair):
+    reference, candidate = three_page_pair
+
+    raised, lines = _compare_and_capture(reference, candidate)
+
+    assert raised == FAILURE_MESSAGE
+    diff_lines = [line for line in lines if "Visual differences detected. SSIM" in line]
+    assert len(diff_lines) == 2, f"expected one line per differing page, got {diff_lines}"
+    assert any(line.startswith("Page 1: ") for line in diff_lines)
+    assert any(line.startswith("Page 3: ") for line in diff_lines)
+    # page 2 is identical and must not be reported
+    assert not any(line.startswith("Page 2: ") for line in diff_lines)
+
+
+def _summaries(lines):
+    return [line for line in lines if line.startswith("Differences detected on")]
+
+
+def test_summary_line_names_affected_pages(three_page_pair):
+    reference, candidate = three_page_pair
+
+    _, lines = _compare_and_capture(reference, candidate)
+
+    summaries = _summaries(lines)
+    assert len(summaries) == 1, f"expected exactly one summary line, got {summaries}"
+    assert "2 of 3 page(s): 1, 3" in summaries[0]
+
+
+def test_summary_precedes_the_per_page_details(three_page_pair):
+    """A leading summary keeps a large multi-page failure scannable."""
+    reference, candidate = three_page_pair
+
+    _, lines = _compare_and_capture(reference, candidate)
+
+    summary_index = next(
+        i for i, line in enumerate(lines) if line.startswith("Differences detected on")
+    )
+    first_detail = next(i for i, line in enumerate(lines) if line.startswith("Page 1: "))
+    assert summary_index < first_detail
+
+
+def test_identical_documents_report_nothing_and_pass(tmp_path):
+    reference = _make_pdf(tmp_path / "a.pdf", ["ONE", "TWO", "THREE"])
+    candidate = _make_pdf(tmp_path / "b.pdf", ["ONE", "TWO", "THREE"])
+
+    raised, lines = _compare_and_capture(reference, candidate)
+
+    assert raised is None
+    assert not [line for line in lines if "differences detected" in line]
+    assert any("comparison passed" in line for line in lines)
+
+
+def test_single_page_failure_message_unchanged(tmp_path):
+    """The exception text is asserted verbatim by 39+ tests across the repo."""
+    reference = _make_pdf(tmp_path / "one_ref.pdf", ["ORIGINAL"])
+    candidate = _make_pdf(tmp_path / "one_cand.pdf", ["CHANGED!!"])
+
+    raised, lines = _compare_and_capture(reference, candidate)
+
+    assert raised == FAILURE_MESSAGE
+    assert any(line.startswith("Page 1: ") for line in lines)
+
+
+def test_single_page_comparison_emits_no_summary(tmp_path):
+    """The summary exists to show later pages were compared — pointless for one page."""
+    reference = _make_pdf(tmp_path / "s_ref.pdf", ["ORIGINAL"])
+    candidate = _make_pdf(tmp_path / "s_cand.pdf", ["CHANGED!!"])
+
+    _, lines = _compare_and_capture(reference, candidate)
+
+    assert _summaries(lines) == []
+
+
+def test_reference_run_clears_differences_and_still_passes(tmp_path):
+    """The `if detected_differences:` guard must let cleared lists through.
+
+    A reference run promotes the candidate and empties the list *after* it was
+    populated — the path that would break if the raise were moved back up.
+    """
+    reference = _make_pdf(tmp_path / "r_ref.pdf", ["ONE", "TWO", "THREE"])
+    candidate = _make_pdf(tmp_path / "r_cand.pdf", ["ONE!!", "TWO", "THREE!!"])
+    tester = VisualTest(take_screenshots=False)
+    tester.set_reference_run(True)
+
+    raised, lines = _compare_and_capture(reference, candidate, tester=tester)
+
+    assert raised is None, "a reference run must not fail"
+    assert any("comparison passed" in line for line in lines)
+    assert _summaries(lines) == []
+
+
+def test_barcode_messages_are_not_double_labelled(tmp_path):
+    """Barcode messages already name their page; they must not be prefixed."""
+    tester = VisualTest(take_screenshots=False)
+    barcode_diff = {
+        "message": "The barcodes on page 2 differ: reference ['A'], candidate ['B']",
+        "page": 2,
+        "type": "barcode",
+    }
+
+    formatted = tester._format_difference_message(barcode_diff)
+
+    assert formatted == barcode_diff["message"]
+    assert formatted.count("page 2") == 1
+    assert not formatted.startswith("Page 2:")
+    # ...but it still contributes its page to the summary
+    assert tester._difference_page_number(barcode_diff) == 2

--- a/utest/test_screenshot_log_style.py
+++ b/utest/test_screenshot_log_style.py
@@ -1,0 +1,90 @@
+"""Screenshots logged to the Robot log must never be upscaled (issue #140).
+
+`width:50%` forced every image to exactly half the log column, so small
+crops (the moved-area / diff-area images from a move_tolerance failure)
+were blown up. `max-width:50%` bounds large images exactly as before while
+letting small ones render at their natural size.
+
+Note: `robot_logger` is `robot.api.logger`, which outside a Robot run routes
+to the Python logger named "RobotFramework" — so `caplog` on the module
+logger captures nothing. These tests patch the imported symbol instead.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from DocTest.VisualTest import VisualTest
+
+BOUNDED_STYLE = "max-width:50%; height: auto;"
+NATURAL_STYLE = "width: auto; height: auto;"
+# The regressed form. Anchored to the start of the style attribute so it is
+# not matched by the "max-width:50%" substring.
+FIXED_WIDTH_STYLE = 'style="width:50%'
+
+
+@pytest.fixture
+def small_image():
+    """A crop far narrower than half a log column — the issue #140 case."""
+    return np.full((20, 40, 3), 200, dtype=np.uint8)
+
+
+def _emit(tester, image, **kwargs):
+    with patch("DocTest.VisualTest.robot_logger") as logger:
+        tester.add_screenshot_to_log(image, "_diff_area", **kwargs)
+    assert logger.info.called, "no screenshot was logged"
+    return logger.info.call_args[0][0]
+
+
+def test_default_file_link_path_bounds_without_upscaling(small_image, tmp_path, monkeypatch):
+    """The shipped default: screenshot_format='jpg', embed_screenshots=False."""
+    monkeypatch.chdir(tmp_path)
+    tester = VisualTest()
+    assert tester.screenshot_format == "jpg"
+    assert tester.embed_screenshots is False
+
+    html = _emit(tester, small_image)
+
+    assert f'style="{BOUNDED_STYLE}"' in html
+    assert FIXED_WIDTH_STYLE not in html
+    # full-size inspection must still be reachable
+    assert 'target="_blank"' in html
+
+
+@pytest.mark.parametrize("screenshot_format", ["jpg", "png"])
+def test_embedded_paths_bound_without_upscaling(
+    small_image, tmp_path, monkeypatch, screenshot_format
+):
+    monkeypatch.chdir(tmp_path)
+    tester = VisualTest(
+        embed_screenshots=True, screenshot_format=screenshot_format
+    )
+
+    html = _emit(tester, small_image)
+
+    assert f'style="{BOUNDED_STYLE}"' in html
+    assert FIXED_WIDTH_STYLE not in html
+    assert "base64," in html
+
+
+def test_original_size_mode_stays_unbounded(small_image, tmp_path, monkeypatch):
+    """`original_size=True` exists so template screenshots keep natural size."""
+    monkeypatch.chdir(tmp_path)
+    tester = VisualTest(embed_screenshots=True)
+
+    html = _emit(tester, small_image, original_size=True)
+
+    assert f'style="{NATURAL_STYLE}"' in html
+    assert "max-width" not in html
+
+
+def test_large_image_is_still_bounded(tmp_path, monkeypatch):
+    """Large screenshots keep the same half-column bound as before."""
+    monkeypatch.chdir(tmp_path)
+    tester = VisualTest(embed_screenshots=True)
+    large = np.full((1200, 1600, 3), 128, dtype=np.uint8)
+
+    html = _emit(tester, large)
+
+    assert f'style="{BOUNDED_STYLE}"' in html

--- a/utest/test_template_detection_config.py
+++ b/utest/test_template_detection_config.py
@@ -1,0 +1,144 @@
+"""Library-level template detection method (issue #127).
+
+`Image Should Contain Template` took a per-call `detection` argument with no
+way to set it once at import. These tests pin the new `template_detection`
+import argument / `Set Template Detection` keyword, the resolution order,
+and that existing suites are unaffected.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from DocTest.VisualTest import VisualTest
+
+
+# --- library-level setting -------------------------------------------------
+
+def test_unset_by_default():
+    assert VisualTest().template_detection is None
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("sift", "sift"),
+        ("orb", "orb"),
+        ("template", "template"),
+        ("SIFT", "sift"),
+        ("  Sift  ", "sift"),
+        ("classic", "template"),
+    ],
+)
+def test_import_argument_is_normalized(given, expected):
+    assert VisualTest(template_detection=given).template_detection == expected
+
+
+@pytest.mark.parametrize("bad", ["bogus", "text"])
+def test_invalid_import_argument_rejected(bad):
+    with pytest.raises(ValueError, match="Unsupported template detection method"):
+        VisualTest(template_detection=bad)
+    # the message must list the supported values
+    with pytest.raises(ValueError, match="orb, sift, template"):
+        VisualTest(template_detection=bad)
+
+
+def test_setter_keyword_sets_and_resets():
+    tester = VisualTest()
+    tester.set_template_detection("sift")
+    assert tester.template_detection == "sift"
+    tester.set_template_detection("template")
+    assert tester.template_detection == "template"
+
+
+def test_setter_keyword_rejects_invalid():
+    with pytest.raises(ValueError, match="Unsupported template detection method"):
+        VisualTest().set_template_detection("text")
+
+
+def test_movement_detection_does_not_leak_into_template_detection():
+    """movement_detection supports 'text', which is invalid here — keep them apart."""
+    tester = VisualTest(movement_detection="text")
+    assert tester.movement_detection == "text"
+    assert tester.template_detection is None
+    assert _resolved(tester) == "template"
+
+
+def test_documented_classic_alias_accepted_for_movement_detection():
+    """README documents movement_detection=classic; it must resolve to template."""
+    assert VisualTest(movement_detection="classic").movement_detection == "template"
+
+
+# --- resolution order inside the keyword ----------------------------------
+
+class _StopBeforeIO(Exception):
+    """Raised in place of loading images, once resolution has happened."""
+
+
+def _resolved(tester, **kwargs):
+    """Return the detection method the keyword resolves to.
+
+    Resolution happens at the top of the keyword, so we spy on the normalizer
+    and abort at the first image load — no fixtures or disk access needed.
+    """
+    seen = {}
+    original = VisualTest._normalize_template_detection
+
+    def spy(self, value):
+        seen["detection"] = original(self, value)
+        return seen["detection"]
+
+    with patch.object(VisualTest, "_normalize_template_detection", spy), patch(
+        "DocTest.VisualTest.DocumentRepresentation", side_effect=_StopBeforeIO
+    ):
+        with pytest.raises(_StopBeforeIO):
+            tester.image_should_contain_template("img.png", "tpl.png", **kwargs)
+    return seen["detection"]
+
+
+def test_resolution_defaults_to_template_when_nothing_set():
+    assert _resolved(VisualTest()) == "template"
+
+
+def test_resolution_uses_library_setting():
+    assert _resolved(VisualTest(template_detection="sift")) == "sift"
+
+
+def test_resolution_uses_setter_value():
+    tester = VisualTest()
+    tester.set_template_detection("orb")
+    assert _resolved(tester) == "orb"
+
+
+def test_explicit_call_argument_wins_over_library_setting():
+    tester = VisualTest(template_detection="sift")
+    assert _resolved(tester, detection="template") == "template"
+
+
+def test_empty_detection_argument_counts_as_not_provided():
+    tester = VisualTest(template_detection="sift")
+    assert _resolved(tester, detection="") == "sift"
+
+
+def test_explicit_call_argument_is_normalized():
+    assert _resolved(VisualTest(), detection="SIFT") == "sift"
+
+
+def test_invalid_call_argument_raises_before_file_access():
+    """Validation is up front, so a bad value fails without touching the disk."""
+    with patch("DocTest.VisualTest.DocumentRepresentation") as doc:
+        with pytest.raises(ValueError, match="Unsupported template detection method"):
+            VisualTest().image_should_contain_template(
+                "img.png", "tpl.png", detection="bogus"
+            )
+        doc.assert_not_called()
+
+
+# --- subclass wiring ------------------------------------------------------
+
+def test_webvisualtest_forwards_the_setting():
+    """WebVisualTest passes **kwargs through, and unknown keys are swallowed
+    silently — so a wiring regression would be invisible without this test."""
+    from DocTest.WebVisualTest import WebVisualTest
+
+    assert WebVisualTest(template_detection="sift").template_detection == "sift"


### PR DESCRIPTION
Fixes #140, fixes #127, fixes #98.

Three OpenSpec change cycles (explore → propose → apply → archive), archived under `openspec/changes/archive/2026-07-30-*`. Every new test was proven non-vacuous by reverting the fix and confirming it fails.

---

## #140 — Small moved sections look huge in logs

Logged screenshots used `style="width:50%"`, which forces *every* image to exactly half the log column and therefore **upscales** small crops — the moved-area images emitted when a `move_tolerance` check fails. Now `max-width:50%`, exactly as the reporter proposed: images at least half the column wide render byte-identically, smaller ones at natural size.

The `original_size=True` branch is deliberately left alone — it exists specifically so template screenshots keep their natural size (commit 3150d8d), and widening it would reverse that.

## #127 — Library-level detection for `Image Should Contain Template`

New `template_detection` import argument and `Set Template Detection` keyword. The keyword's `detection` argument now resolves: explicit call argument → library setting → `template`.

**Suites that set neither behave exactly as before** — resolution terminates at `template`, so only the libdoc-rendered default changes. That is why both reviewed signature baselines are regenerated rather than the change being avoided.

`movement_detection` is deliberately *not* reused (the issue's option 1): it accepts `text`, which is not a template-matching method, and reusing it would silently change behavior for existing users. This implements the issue title's own option — "Add a detection library import argument".

Documented in the `__init__` argument table, the package docstring (what the published keyword docs render) and the README. The setter's `TEST` scope is stated explicitly: it applies to the current test, not the whole suite.

### Bonus fix found while designing this

`movement_detection=classic` is **documented in the README but was rejected at import**. The `Literal[...]` type hint made Robot Framework convert — and refuse — the value before `MOVEMENT_DETECTION_ALIASES` could run, making the alias table dead code:

```
ValueError: Argument 'movement_detection' got value 'classic'
that cannot be converted to 'template', 'orb', 'sift' or 'text'.
```

Widened to a plain `str` hint; validation and error messages are unchanged. Verified through a real Robot import, which is the only path that exercises argument type conversion — hence the new acceptance suite.

## #98 — Compare all pages even if the first one fails

The diagnosis differs from the report: **all pages were always compared.** For a 3-page pair differing on pages 1 and 3, both differences were collected and screenshots emitted for both. The bug was purely in reporting — `_raise_comparison_failure()` was called *inside* the `for diff in detected_differences` loop, so only the first difference was ever logged, and that message did not name its page.

Now every difference is logged and the failure is raised once:

```
Differences detected on 2 of 3 page(s): 1, 3
Page 1: Visual differences detected. SSIM score: 0.010999...
Page 3: Visual differences detected. SSIM score: 0.010906...
```

- The summary is suppressed for single-page documents and worded neutrally, since a difference may be non-visual (differing barcode content on pixel-identical pages).
- Barcode messages already name their page and are left unprefixed, to avoid double labelling.
- The `AssertionError` text is **unchanged** — 39+ assertions across `atest/`, `utest/` and `e2e/` match `The compared images are different.` exactly, and Robot's report shows only that text.
- `PdfTest.compare_pdf_documents` was checked and already accumulates before raising once; no change needed.

---

## Backwards compatibility

Keyword names, argument names and import paths are unchanged. The one surface change — `detection`'s default becoming a `None` sentinel — is behavior-preserving and covered by the regenerated baselines, whose only diffs are that default and the added `Set Template Detection` keyword. A stray `@keyword` decorator that briefly leaked a private helper as a public keyword was caught by that same gate and fixed.

## Verification

- **830 unit tests** pass, 3 skipped
- Acceptance suites pass: Compare, Barcode, PdfContent, MovementDetection, ReferenceRun, ResultJson, PrintJobs, plus the new `atest/TemplateDetection.robot` (6 tests)
- `ruff` green
- An adversarial review pass over the diff found no correctness defects; its documentation findings are folded in

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)