### PR TITLE
test: hoist constructors out of pytest.raises blocks

### DIFF
--- a/utest/test_template_detection_config.py
+++ b/utest/test_template_detection_config.py
@@ -52,8 +52,11 @@ def test_setter_keyword_sets_and_resets():
 
 
 def test_setter_keyword_rejects_invalid():
+    # Constructed outside the raises block so only the call under test can
+    # satisfy the assertion.
+    tester = VisualTest()
     with pytest.raises(ValueError, match="Unsupported template detection method"):
-        VisualTest().set_template_detection("text")
+        tester.set_template_detection("text")
 
 
 def test_movement_detection_does_not_leak_into_template_detection():
@@ -126,9 +129,12 @@ def test_explicit_call_argument_is_normalized():
 
 def test_invalid_call_argument_raises_before_file_access():
     """Validation is up front, so a bad value fails without touching the disk."""
+    # Constructed outside the raises block so only the call under test can
+    # satisfy the assertion.
+    tester = VisualTest()
     with patch("DocTest.VisualTest.DocumentRepresentation") as doc:
         with pytest.raises(ValueError, match="Unsupported template detection method"):
-            VisualTest().image_should_contain_template(
+            tester.image_should_contain_template(
                 "img.png", "tpl.png", detection="bogus"
             )
         doc.assert_not_called()


### PR DESCRIPTION
Follow-up to #151, clearing the two SonarCloud findings it introduced.

Both were the same pattern in `utest/test_template_detection_config.py`: `VisualTest()` was constructed **inside** the `pytest.raises` block, so a constructor failure would have satisfied the assertion for the wrong reason.

```python
# before
with pytest.raises(ValueError, match="Unsupported template detection method"):
    VisualTest().set_template_detection("text")

# after
tester = VisualTest()
with pytest.raises(ValueError, match="Unsupported template detection method"):
    tester.set_template_detection("text")
```

Verified the tests remain discriminating: with the validation they cover removed from `_normalize_template_detection`, both still fail; with it restored, both pass.

I also scanned the other test files added in #151 (`test_multipage_reporting.py`, `test_screenshot_log_style.py`) — no other instances of the pattern.

Test-only change; no product code touched. Full unit suite: 830 passed, 3 skipped.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
